### PR TITLE
cli: fix install/update latest version picker

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -106,7 +106,7 @@ function select_branch {
   branch=""
   regex="refs/tags/v[0-9]*\.[0-9]*\.[0-9]*+cli"
   if git ls-remote --tags "$REPO" | grep -q "$regex"; then
-    branch="$(git ls-remote --tags "$REPO" | grep "$regex" | sort -V | tail -n 1 | awk '{print $2}')"
+    branch="$(git ls-remote --tags "$REPO" | grep "$regex" | awk '{print $2}' | sort -V | tail -n 1)"
   else
     # otherwise error
     echo "No tag of the form vX.Y.Z+cli found" >&2

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/ntt-cli",
-  "version": "0.5.0",
+  "version": "1.0.2-beta",
   "module": "src/index.ts",
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
The `git ls-remote` command formats its output as follows:
```
fc0f34f97ecb0e9b0b21622cb1817700ed7f4a49	refs/tags/v1.0.0+cli
a1c11ef5958113b6a00b93967e8cef54c887a639	refs/tags/v1.0.1+cli
```
so when we sort it, it actually sorts the git hashes, and not the versions. So we rearrange the commands to first drop the commit hashes and then the sort (rather than doing it the other way around like before).