### PR TITLE
sdk: quote destination amount truncation fix

### DIFF
--- a/sdk/route/src/manual.ts
+++ b/sdk/route/src/manual.ts
@@ -103,6 +103,15 @@ export class NttManualRoute<N extends Network>
     const options = params.options ?? this.getDefaultOptions();
 
     const amt = amount.parse(params.amount, request.source.decimals);
+    // remove dust to avoid `TransferAmountHasDust` revert reason
+    const truncatedAmount = amount.truncate(
+      amt,
+      Math.min(
+        request.source.decimals,
+        request.destination.decimals,
+        NttRoute.TRIMMED_DECIMALS
+      )
+    );
     const gasDropoff = amount.units(
       amount.parse(
         options.gasDropoff ?? "0.0",
@@ -113,7 +122,7 @@ export class NttManualRoute<N extends Network>
     const validatedParams: Vp = {
       amount: params.amount,
       normalizedParams: {
-        amount: amt,
+        amount: truncatedAmount,
         sourceContracts: NttRoute.resolveNttContracts(
           this.staticConfig,
           request.source.id
@@ -137,6 +146,11 @@ export class NttManualRoute<N extends Network>
     request: routes.RouteTransferRequest<N>,
     params: Vp
   ): Promise<QR> {
+    const dstAmount = amount.scale(
+      params.normalizedParams.amount,
+      request.destination.decimals
+    );
+
     const result: QR = {
       success: true,
       params,
@@ -146,7 +160,7 @@ export class NttManualRoute<N extends Network>
       },
       destinationToken: {
         token: request.destination.id,
-        amount: amount.parse(params.amount, request.destination.decimals),
+        amount: dstAmount,
       },
       eta: finality.estimateFinalityTime(request.fromChain.chain),
     };
@@ -157,10 +171,6 @@ export class NttManualRoute<N extends Network>
     const duration = await dstNtt.getRateLimitDuration();
     if (duration > 0n) {
       const capacity = await dstNtt.getCurrentInboundCapacity(fromChain.chain);
-      const dstAmount = amount.parse(
-        params.amount,
-        request.destination.decimals
-      );
       if (
         NttRoute.isCapacityThresholdExceeded(amount.units(dstAmount), capacity)
       ) {

--- a/sdk/route/src/types.ts
+++ b/sdk/route/src/types.ts
@@ -18,6 +18,8 @@ export namespace NttRoute {
   // Currently only wormhole attestations supported
   export type TransceiverType = "wormhole";
 
+  export const TRIMMED_DECIMALS = 8;
+
   export type TransceiverConfig = {
     type: TransceiverType;
     address: string;


### PR DESCRIPTION
Fixes an issue where calling quote with an amount that has more fractional digits than the destination chain supports throws an error. We need to truncate and scale the destination amount to destination chain decimals.