### PR TITLE
tilt: solana-test-validator multi-platform support

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -2,7 +2,7 @@ load('ext://namespace', 'namespace_create', 'namespace_inject')
 load('ext://git_resource', 'git_checkout')
 
 git_checkout('https://github.com/wormhole-foundation/wormhole.git#main', '.wormhole/', unsafe_mode=True)
-local(['sed','-i','/{chainId: vaa.ChainIDEthereum, addr: "000000000000000000000000855FA758c77D68a04990E992aA4dcdeF899F654A"},/i {chainId: vaa.ChainIDSolana, addr: "8bf0b547c96edc5c1d512ca25c5c1d1812a180438a0046e511d1fb61561d5cdf"},{chainId: vaa.ChainIDSolana, addr: "0a490691c21334ca173d9ce386e2a86774ce173f351db10d5d0cccc5c4875376"},{chainId: vaa.ChainIDEthereum, addr: "0000000000000000000000006f84742680311cef5ba42bc10a71a4708b4561d1"},{chainId: vaa.ChainIDEthereum, addr: "0000000000000000000000009ba423008e530c4d464da15f0c9652942216f019"},{chainId: vaa.ChainIDBSC, addr: "0000000000000000000000006f84742680311cef5ba42bc10a71a4708b4561d1"},{chainId: vaa.ChainIDBSC, addr: "000000000000000000000000baac7efcddde498b0b791eda92d43b20f5cd8ff6"},', '.wormhole/node/pkg/accountant/ntt_config.go'])
+local(['sed','-i.bak','s/{chainId: vaa.ChainIDEthereum, addr: "000000000000000000000000855FA758c77D68a04990E992aA4dcdeF899F654A"},/{chainId: vaa.ChainIDEthereum, addr: "000000000000000000000000855FA758c77D68a04990E992aA4dcdeF899F654A"},{chainId: vaa.ChainIDSolana, addr: "8bf0b547c96edc5c1d512ca25c5c1d1812a180438a0046e511d1fb61561d5cdf"},{chainId: vaa.ChainIDSolana, addr: "0a490691c21334ca173d9ce386e2a86774ce173f351db10d5d0cccc5c4875376"},{chainId: vaa.ChainIDEthereum, addr: "0000000000000000000000006f84742680311cef5ba42bc10a71a4708b4561d1"},{chainId: vaa.ChainIDEthereum, addr: "0000000000000000000000009ba423008e530c4d464da15f0c9652942216f019"},{chainId: vaa.ChainIDBSC, addr: "0000000000000000000000006f84742680311cef5ba42bc10a71a4708b4561d1"},{chainId: vaa.ChainIDBSC, addr: "000000000000000000000000baac7efcddde498b0b791eda92d43b20f5cd8ff6"},/g', '.wormhole/node/pkg/accountant/ntt_config.go'])
 
 load(".wormhole/Tiltfile", "namespace", "k8s_yaml_with_ns")
 
@@ -13,6 +13,11 @@ docker_build(
     only = ["./sdk", "./solana"],
     ignore=["./sdk/__tests__", "./sdk/Dockerfile", "./sdk/ci.yaml", "./sdk/**/dist", "./sdk/node_modules", "./sdk/**/node_modules"],
     dockerfile = "./solana/Dockerfile",
+)
+docker_build(
+    ref = "solana-test-validator",
+    context = "solana",
+    dockerfile = "solana/Dockerfile.test-validator"
 )
 k8s_yaml_with_ns("./solana/solana-devnet.yaml")
 k8s_resource(

--- a/evm/Dockerfile
+++ b/evm/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/foundry-rs/foundry@sha256:8b843eb65cc7b155303b316f65d27173c862b37719dc095ef3a2ef27ce8d3c00 as builder
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry@sha256:8b843eb65cc7b155303b316f65d27173c862b37719dc095ef3a2ef27ce8d3c00 as builder
 
 WORKDIR /app
 COPY foundry.toml foundry.toml

--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -42,3 +42,13 @@ COPY solana/Makefile Makefile
 COPY solana/scripts scripts
 
 RUN make target/idl/example_native_token_transfers.json
+
+FROM scratch as export
+
+COPY --from=builder /opt/solana/deps /opt/solana/deps
+COPY --from=builder /usr/src/solana/ts /usr/src/solana/ts
+COPY --from=builder /usr/src/solana/package.json /usr/src/solana/package.json
+COPY --from=builder /usr/src/solana/tsconfig.esm.json /usr/src/solana/tsconfig.esm.json
+COPY --from=builder /usr/src/solana/tsconfig.cjs.json /usr/src/solana/tsconfig.cjs.json
+COPY --from=builder /usr/src/solana/target/idl  /usr/src/solana/target/idl 
+COPY --from=builder /usr/src/solana/target/types /usr/src/solana/target/types

--- a/solana/Dockerfile.test-validator
+++ b/solana/Dockerfile.test-validator
@@ -1,0 +1,2 @@
+FROM ghcr.io/wormholelabs-xyz/solana-test-validator:1.17.29@sha256:b1f85eed2d33a2bd0378204ab4d1e16537de35407cdcfeedbd021b31636618bc
+COPY --from=ntt-solana-contract /opt/solana/deps/ /opt/solana/deps/

--- a/solana/solana-devnet.yaml
+++ b/solana/solana-devnet.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
         - name: solana-devnet
-          image: ntt-solana-contract
+          image: solana-test-validator
           command:
             - solana-test-validator
             - --bpf-program


### PR DESCRIPTION
This PR adds support for solana-test-validator within Docker / Tilt for M-series Macs. See also https://github.com/wormhole-foundation/wormhole/pull/4175 and https://github.com/wormhole-foundation/wormhole/pull/4181 which made this possible.

It also changes the `sed` line to one that works on Mac and Linux / WSL. To confirm that line still works in ci, I did a run with the guardian log level on `info` [here](https://github.com/wormhole-foundation/native-token-transfers/actions/runs/12204869868/job/34050904852?pr=563) where you can search for `8bf0b547c96edc5c1d512ca25c5c1d1812a180438a0046e511d1fb61561d5cdf` and the other emitters added to confirm they are being accounted (search for `gacct` guardian logs).

Bonus: this changes the result of `solana/Dockerfile` to only contain the required artifacts, reducing the image size from 24.82 GB to 5.27 MB!

oh, and you can now run `tilt up -- --evm2 --generic_relayer --solana_watcher --wormchain --guardiand_loglevel=warn` on your Mac just like in CI and it passes!