### PR TITLE
solana: Allow transferring mint authority

### DIFF
--- a/solana/programs/example-native-token-transfers/src/error.rs
+++ b/solana/programs/example-native-token-transfers/src/error.rs
@@ -53,6 +53,8 @@ pub enum NTTError {
     BitmapIndexOutOfBounds,
     #[msg("NoRegisteredTransceivers")]
     NoRegisteredTransceivers,
+    #[msg("NotPaused")]
+    NotPaused,
 }
 
 impl From<ScalingError> for NTTError {

--- a/solana/programs/example-native-token-transfers/src/error.rs
+++ b/solana/programs/example-native-token-transfers/src/error.rs
@@ -55,6 +55,10 @@ pub enum NTTError {
     NoRegisteredTransceivers,
     #[msg("NotPaused")]
     NotPaused,
+    #[msg("InvalidPendingTokenAuthority")]
+    InvalidPendingTokenAuthority,
+    #[msg("IncorrectRentPayer")]
+    IncorrectRentPayer,
 }
 
 impl From<ScalingError> for NTTError {

--- a/solana/programs/example-native-token-transfers/src/instructions/admin.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin.rs
@@ -183,7 +183,7 @@ pub struct SetTokenAuthority<'info> {
     /// CHECK: The constraints enforce this is valid mint authority
     pub token_authority: UncheckedAccount<'info>,
 
-    /// CHECK: This account will be the signer in the [claim_token_authority] instruction.
+    /// CHECK: The rent payer of the [PendingTokenAuthority] storing this account will be the signer in the [claim_token_authority] instruction.
     pub new_authority: UncheckedAccount<'info>,
 }
 
@@ -277,7 +277,8 @@ pub struct ClaimTokenAuthority<'info> {
             || new_authority.key() == token_authority.key()
         ) @ NTTError::InvalidPendingTokenAuthority
     )]
-    pub new_authority: Signer<'info>,
+    /// CHECK: constraint ensures that this is the correct address
+    pub new_authority: UncheckedAccount<'info>,
 
     #[account(
         mut,

--- a/solana/programs/example-native-token-transfers/src/instructions/admin.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin.rs
@@ -426,7 +426,7 @@ pub fn register_transceiver(ctx: Context<RegisterTransceiver>) -> Result<()> {
 #[derive(Accounts)]
 pub struct SetOutboundLimit<'info> {
     #[account(
-        constraint = config.owner == owner.key()
+        has_one = owner,
     )]
     pub config: Account<'info, Config>,
 
@@ -453,7 +453,7 @@ pub fn set_outbound_limit(
 #[instruction(args: SetInboundLimitArgs)]
 pub struct SetInboundLimit<'info> {
     #[account(
-        constraint = config.owner == owner.key()
+        has_one = owner,
     )]
     pub config: Account<'info, Config>,
 

--- a/solana/programs/example-native-token-transfers/src/instructions/admin.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin.rs
@@ -162,16 +162,14 @@ pub fn claim_ownership(ctx: Context<ClaimOwnership>) -> Result<()> {
 pub struct SetTokenAuthority<'info> {
     #[account(
         has_one = owner,
+        has_one = mint,
         constraint = config.paused @ NTTError::NotPaused,
     )]
     pub config: Account<'info, Config>,
 
     pub owner: Signer<'info>,
 
-    #[account(
-        mut,
-        address = config.mint,
-    )]
+    #[account(mut)]
     /// CHECK: the mint address matches the config
     pub mint: InterfaceAccount<'info, token_interface::Mint>,
 
@@ -249,14 +247,12 @@ pub fn set_token_authority_one_step_unchecked(
 #[derive(Accounts)]
 pub struct RevertTokenAuthority<'info> {
     #[account(
+        has_one = mint,
         constraint = config.paused @ NTTError::NotPaused,
     )]
     pub config: Account<'info, Config>,
 
-    #[account(
-        mut,
-        address = config.mint,
-    )]
+    #[account(mut)]
     /// CHECK: the mint address matches the config
     pub mint: InterfaceAccount<'info, token_interface::Mint>,
 

--- a/solana/programs/example-native-token-transfers/src/instructions/admin.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin.rs
@@ -178,7 +178,6 @@ pub struct SetTokenAuthority<'info> {
     #[account(
         seeds = [crate::TOKEN_AUTHORITY_SEED],
         bump,
-        address = mint.mint_authority.unwrap() @ NTTError::InvalidMintAuthority
     )]
     /// CHECK: The constraints enforce this is valid mint authority
     pub token_authority: UncheckedAccount<'info>,
@@ -189,6 +188,9 @@ pub struct SetTokenAuthority<'info> {
 
 #[derive(Accounts)]
 pub struct SetTokenAuthorityChecked<'info> {
+    #[account(
+        constraint = common.token_authority.key() == common.mint.mint_authority.unwrap() @ NTTError::InvalidMintAuthority
+    )]
     pub common: SetTokenAuthority<'info>,
 
     #[account(mut)]

--- a/solana/programs/example-native-token-transfers/src/instructions/admin.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin.rs
@@ -156,10 +156,12 @@ pub fn claim_ownership(ctx: Context<ClaimOwnership>) -> Result<()> {
 }
 
 // * Set token authority
+
 #[derive(Accounts)]
 pub struct SetTokenAuthority<'info> {
     #[account(
-        constraint = config.owner == owner.key()
+        has_one = owner,
+        constraint = config.paused @ NTTError::NotPaused,
     )]
     pub config: Account<'info, Config>,
 
@@ -178,7 +180,7 @@ pub struct SetTokenAuthority<'info> {
         seeds = [crate::TOKEN_AUTHORITY_SEED],
         bump,
     )]
-    /// CHECK: The seeds constraint enforces that this is the correct account.
+    /// CHECK: token_program will ensure this is the valid mint_authority.
     pub token_authority: UncheckedAccount<'info>,
 
     /// CHECK: This is unsafe as is so should be used with caution

--- a/solana/programs/example-native-token-transfers/src/instructions/admin.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin.rs
@@ -283,7 +283,7 @@ pub fn set_token_authority_one_step_unchecked(
 // * Claim token authority
 
 #[derive(Accounts)]
-pub struct RevertTokenAuthority<'info> {
+pub struct ClaimTokenAuthorityBase<'info> {
     #[account(
         has_one = mint,
         constraint = config.paused @ NTTError::NotPaused,
@@ -318,13 +318,23 @@ pub struct RevertTokenAuthority<'info> {
     pub system_program: Program<'info, System>,
 }
 
+#[derive(Accounts)]
+pub struct RevertTokenAuthority<'info> {
+    pub common: ClaimTokenAuthorityBase<'info>,
+
+    #[account(
+        address = common.config.owner
+    )]
+    pub owner: Signer<'info>,
+}
+
 pub fn revert_token_authority(_ctx: Context<RevertTokenAuthority>) -> Result<()> {
     Ok(())
 }
 
 #[derive(Accounts)]
 pub struct ClaimTokenAuthority<'info> {
-    pub common: RevertTokenAuthority<'info>,
+    pub common: ClaimTokenAuthorityBase<'info>,
 
     #[account(
         address = common.pending_token_authority.pending_authority @ NTTError::InvalidPendingTokenAuthority

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -126,6 +126,10 @@ pub mod example_native_token_transfers {
         instructions::claim_ownership(ctx)
     }
 
+    pub fn set_token_authority_one_step_unchecked(ctx: Context<SetTokenAuthority>) -> Result<()> {
+        instructions::set_token_authority_one_step_unchecked(ctx)
+    }
+
     pub fn set_paused(ctx: Context<SetPaused>, pause: bool) -> Result<()> {
         instructions::set_paused(ctx, pause)
     }

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -137,6 +137,10 @@ pub mod example_native_token_transfers {
         instructions::set_token_authority_one_step_unchecked(ctx)
     }
 
+    pub fn revert_token_authority(ctx: Context<RevertTokenAuthority>) -> Result<()> {
+        instructions::revert_token_authority(ctx)
+    }
+
     pub fn claim_token_authority(ctx: Context<ClaimTokenAuthority>) -> Result<()> {
         instructions::claim_token_authority(ctx)
     }

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -18,6 +18,7 @@ pub mod error;
 pub mod instructions;
 pub mod messages;
 pub mod peer;
+pub mod pending_token_authority;
 pub mod queue;
 pub mod registered_transceiver;
 pub mod transceivers;
@@ -126,8 +127,18 @@ pub mod example_native_token_transfers {
         instructions::claim_ownership(ctx)
     }
 
-    pub fn set_token_authority_one_step_unchecked(ctx: Context<SetTokenAuthority>) -> Result<()> {
+    pub fn set_token_authority(ctx: Context<SetTokenAuthorityChecked>) -> Result<()> {
+        instructions::set_token_authority(ctx)
+    }
+
+    pub fn set_token_authority_one_step_unchecked(
+        ctx: Context<SetTokenAuthorityUnchecked>,
+    ) -> Result<()> {
         instructions::set_token_authority_one_step_unchecked(ctx)
+    }
+
+    pub fn claim_token_authority(ctx: Context<ClaimTokenAuthority>) -> Result<()> {
+        instructions::claim_token_authority(ctx)
     }
 
     pub fn set_paused(ctx: Context<SetPaused>, pause: bool) -> Result<()> {

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -127,6 +127,10 @@ pub mod example_native_token_transfers {
         instructions::claim_ownership(ctx)
     }
 
+    pub fn accept_token_authority(ctx: Context<AcceptTokenAuthority>) -> Result<()> {
+        instructions::accept_token_authority(ctx)
+    }
+
     pub fn set_token_authority(ctx: Context<SetTokenAuthorityChecked>) -> Result<()> {
         instructions::set_token_authority(ctx)
     }

--- a/solana/programs/example-native-token-transfers/src/pending_token_authority.rs
+++ b/solana/programs/example-native-token-transfers/src/pending_token_authority.rs
@@ -1,0 +1,13 @@
+use anchor_lang::prelude::*;
+
+#[account]
+#[derive(InitSpace)]
+pub struct PendingTokenAuthority {
+    pub bump: u8,
+    pub pending_authority: Pubkey,
+    pub rent_payer: Pubkey,
+}
+
+impl PendingTokenAuthority {
+    pub const SEED_PREFIX: &'static [u8] = b"pending_token_authority";
+}

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -720,6 +720,37 @@
       "args": []
     },
     {
+      "name": "acceptTokenAuthority",
+      "accounts": [
+        {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "currentAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "setTokenAuthority",
       "accounts": [
         {

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -720,7 +720,99 @@
       "args": []
     },
     {
+      "name": "setTokenAuthority",
+      "accounts": [
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "owner",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "newAuthority",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "pendingTokenAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "setTokenAuthorityOneStepUnchecked",
+      "accounts": [
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "owner",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "newAuthority",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claimTokenAuthority",
       "accounts": [
         {
           "name": "config",
@@ -728,18 +820,13 @@
           "isSigner": false
         },
         {
-          "name": "owner",
-          "isMut": false,
+          "name": "payer",
+          "isMut": true,
           "isSigner": true
         },
         {
           "name": "mint",
           "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
           "isSigner": false
         },
         {
@@ -749,6 +836,21 @@
         },
         {
           "name": "newAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "pendingTokenAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
           "isMut": false,
           "isSigner": false
         }
@@ -1413,6 +1515,26 @@
       }
     },
     {
+      "name": "PendingTokenAuthority",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pendingAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "rentPayer",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
       "name": "InboxItem",
       "type": {
         "kind": "struct",
@@ -2060,6 +2182,16 @@
       "code": 6024,
       "name": "NotPaused",
       "msg": "NotPaused"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidPendingTokenAuthority",
+      "msg": "InvalidPendingTokenAuthority"
+    },
+    {
+      "code": 6026,
+      "name": "IncorrectRentPayer",
+      "msg": "IncorrectRentPayer"
     }
   ]
 }

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -837,7 +837,7 @@
         {
           "name": "newAuthority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "pendingTokenAuthority",

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -720,6 +720,42 @@
       "args": []
     },
     {
+      "name": "setTokenAuthorityOneStepUnchecked",
+      "accounts": [
+        {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newAuthority",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "setPaused",
       "accounts": [
         {

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -2055,6 +2055,11 @@
       "code": 6023,
       "name": "NoRegisteredTransceivers",
       "msg": "NoRegisteredTransceivers"
+    },
+    {
+      "code": 6024,
+      "name": "NotPaused",
+      "msg": "NotPaused"
     }
   ]
 }

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -753,7 +753,7 @@
           ]
         },
         {
-          "name": "payer",
+          "name": "rentPayer",
           "isMut": true,
           "isSigner": true
         },
@@ -820,11 +820,6 @@
           "isSigner": false
         },
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
           "name": "mint",
           "isMut": true,
           "isSigner": false
@@ -832,6 +827,11 @@
         {
           "name": "tokenAuthority",
           "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
           "isSigner": false
         },
         {
@@ -864,11 +864,6 @@
               "isSigner": false
             },
             {
-              "name": "payer",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
               "name": "mint",
               "isMut": true,
               "isSigner": false
@@ -876,6 +871,11 @@
             {
               "name": "tokenAuthority",
               "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "rentPayer",
+              "isMut": true,
               "isSigner": false
             },
             {

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -812,7 +812,7 @@
       "args": []
     },
     {
-      "name": "claimTokenAuthority",
+      "name": "revertTokenAuthority",
       "accounts": [
         {
           "name": "config",
@@ -822,7 +822,7 @@
         {
           "name": "payer",
           "isMut": true,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "mint",
@@ -831,11 +831,6 @@
         },
         {
           "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "newAuthority",
           "isMut": false,
           "isSigner": false
         },
@@ -853,6 +848,57 @@
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claimTokenAuthority",
+      "accounts": [
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "payer",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "pendingTokenAuthority",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "systemProgram",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "newAuthority",
+          "isMut": false,
+          "isSigner": true
         }
       ],
       "args": []

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -846,39 +846,49 @@
       "name": "revertTokenAuthority",
       "accounts": [
         {
-          "name": "config",
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "rentPayer",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "pendingTokenAuthority",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "systemProgram",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "owner",
           "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "mint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rentPayer",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "pendingTokenAuthority",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "isSigner": true
         }
       ],
       "args": []

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -720,7 +720,99 @@ export type ExampleNativeTokenTransfers = {
       "args": []
     },
     {
+      "name": "setTokenAuthority",
+      "accounts": [
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "owner",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "newAuthority",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "pendingTokenAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "setTokenAuthorityOneStepUnchecked",
+      "accounts": [
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "owner",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "newAuthority",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claimTokenAuthority",
       "accounts": [
         {
           "name": "config",
@@ -728,18 +820,13 @@ export type ExampleNativeTokenTransfers = {
           "isSigner": false
         },
         {
-          "name": "owner",
-          "isMut": false,
+          "name": "payer",
+          "isMut": true,
           "isSigner": true
         },
         {
           "name": "mint",
           "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
           "isSigner": false
         },
         {
@@ -749,6 +836,21 @@ export type ExampleNativeTokenTransfers = {
         },
         {
           "name": "newAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "pendingTokenAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
           "isMut": false,
           "isSigner": false
         }
@@ -1413,6 +1515,26 @@ export type ExampleNativeTokenTransfers = {
       }
     },
     {
+      "name": "pendingTokenAuthority",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pendingAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "rentPayer",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
       "name": "inboxItem",
       "type": {
         "kind": "struct",
@@ -2060,6 +2182,16 @@ export type ExampleNativeTokenTransfers = {
       "code": 6024,
       "name": "NotPaused",
       "msg": "NotPaused"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidPendingTokenAuthority",
+      "msg": "InvalidPendingTokenAuthority"
+    },
+    {
+      "code": 6026,
+      "name": "IncorrectRentPayer",
+      "msg": "IncorrectRentPayer"
     }
   ]
 }
@@ -2785,7 +2917,99 @@ export const IDL: ExampleNativeTokenTransfers = {
       "args": []
     },
     {
+      "name": "setTokenAuthority",
+      "accounts": [
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "owner",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "newAuthority",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "pendingTokenAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "setTokenAuthorityOneStepUnchecked",
+      "accounts": [
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "owner",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "newAuthority",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claimTokenAuthority",
       "accounts": [
         {
           "name": "config",
@@ -2793,18 +3017,13 @@ export const IDL: ExampleNativeTokenTransfers = {
           "isSigner": false
         },
         {
-          "name": "owner",
-          "isMut": false,
+          "name": "payer",
+          "isMut": true,
           "isSigner": true
         },
         {
           "name": "mint",
           "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
           "isSigner": false
         },
         {
@@ -2814,6 +3033,21 @@ export const IDL: ExampleNativeTokenTransfers = {
         },
         {
           "name": "newAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "pendingTokenAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
           "isMut": false,
           "isSigner": false
         }
@@ -3478,6 +3712,26 @@ export const IDL: ExampleNativeTokenTransfers = {
       }
     },
     {
+      "name": "pendingTokenAuthority",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pendingAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "rentPayer",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
       "name": "inboxItem",
       "type": {
         "kind": "struct",
@@ -4125,6 +4379,16 @@ export const IDL: ExampleNativeTokenTransfers = {
       "code": 6024,
       "name": "NotPaused",
       "msg": "NotPaused"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidPendingTokenAuthority",
+      "msg": "InvalidPendingTokenAuthority"
+    },
+    {
+      "code": 6026,
+      "name": "IncorrectRentPayer",
+      "msg": "IncorrectRentPayer"
     }
   ]
 }

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -720,6 +720,42 @@ export type ExampleNativeTokenTransfers = {
       "args": []
     },
     {
+      "name": "setTokenAuthorityOneStepUnchecked",
+      "accounts": [
+        {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newAuthority",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "setPaused",
       "accounts": [
         {
@@ -2737,6 +2773,42 @@ export const IDL: ExampleNativeTokenTransfers = {
         },
         {
           "name": "bpfLoaderUpgradeableProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "setTokenAuthorityOneStepUnchecked",
+      "accounts": [
+        {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newAuthority",
           "isMut": false,
           "isSigner": false
         }

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -720,6 +720,37 @@ export type ExampleNativeTokenTransfers = {
       "args": []
     },
     {
+      "name": "acceptTokenAuthority",
+      "accounts": [
+        {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "currentAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "setTokenAuthority",
       "accounts": [
         {
@@ -2956,6 +2987,37 @@ export const IDL: ExampleNativeTokenTransfers = {
         },
         {
           "name": "bpfLoaderUpgradeableProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "acceptTokenAuthority",
+      "accounts": [
+        {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "currentAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "tokenProgram",
           "isMut": false,
           "isSigner": false
         }

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -2055,6 +2055,11 @@ export type ExampleNativeTokenTransfers = {
       "code": 6023,
       "name": "NoRegisteredTransceivers",
       "msg": "NoRegisteredTransceivers"
+    },
+    {
+      "code": 6024,
+      "name": "NotPaused",
+      "msg": "NotPaused"
     }
   ]
 }
@@ -4115,6 +4120,11 @@ export const IDL: ExampleNativeTokenTransfers = {
       "code": 6023,
       "name": "NoRegisteredTransceivers",
       "msg": "NoRegisteredTransceivers"
+    },
+    {
+      "code": 6024,
+      "name": "NotPaused",
+      "msg": "NotPaused"
     }
   ]
 }

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -812,7 +812,7 @@ export type ExampleNativeTokenTransfers = {
       "args": []
     },
     {
-      "name": "claimTokenAuthority",
+      "name": "revertTokenAuthority",
       "accounts": [
         {
           "name": "config",
@@ -822,7 +822,7 @@ export type ExampleNativeTokenTransfers = {
         {
           "name": "payer",
           "isMut": true,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "mint",
@@ -831,11 +831,6 @@ export type ExampleNativeTokenTransfers = {
         },
         {
           "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "newAuthority",
           "isMut": false,
           "isSigner": false
         },
@@ -853,6 +848,57 @@ export type ExampleNativeTokenTransfers = {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claimTokenAuthority",
+      "accounts": [
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "payer",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "pendingTokenAuthority",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "systemProgram",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "newAuthority",
+          "isMut": false,
+          "isSigner": true
         }
       ],
       "args": []
@@ -3009,7 +3055,7 @@ export const IDL: ExampleNativeTokenTransfers = {
       "args": []
     },
     {
-      "name": "claimTokenAuthority",
+      "name": "revertTokenAuthority",
       "accounts": [
         {
           "name": "config",
@@ -3019,7 +3065,7 @@ export const IDL: ExampleNativeTokenTransfers = {
         {
           "name": "payer",
           "isMut": true,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "mint",
@@ -3028,11 +3074,6 @@ export const IDL: ExampleNativeTokenTransfers = {
         },
         {
           "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "newAuthority",
           "isMut": false,
           "isSigner": false
         },
@@ -3050,6 +3091,57 @@ export const IDL: ExampleNativeTokenTransfers = {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claimTokenAuthority",
+      "accounts": [
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "payer",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "pendingTokenAuthority",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "systemProgram",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "newAuthority",
+          "isMut": false,
+          "isSigner": true
         }
       ],
       "args": []

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -837,7 +837,7 @@ export type ExampleNativeTokenTransfers = {
         {
           "name": "newAuthority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "pendingTokenAuthority",
@@ -3034,7 +3034,7 @@ export const IDL: ExampleNativeTokenTransfers = {
         {
           "name": "newAuthority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "pendingTokenAuthority",

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -753,7 +753,7 @@ export type ExampleNativeTokenTransfers = {
           ]
         },
         {
-          "name": "payer",
+          "name": "rentPayer",
           "isMut": true,
           "isSigner": true
         },
@@ -820,11 +820,6 @@ export type ExampleNativeTokenTransfers = {
           "isSigner": false
         },
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
           "name": "mint",
           "isMut": true,
           "isSigner": false
@@ -832,6 +827,11 @@ export type ExampleNativeTokenTransfers = {
         {
           "name": "tokenAuthority",
           "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
           "isSigner": false
         },
         {
@@ -864,11 +864,6 @@ export type ExampleNativeTokenTransfers = {
               "isSigner": false
             },
             {
-              "name": "payer",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
               "name": "mint",
               "isMut": true,
               "isSigner": false
@@ -876,6 +871,11 @@ export type ExampleNativeTokenTransfers = {
             {
               "name": "tokenAuthority",
               "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "rentPayer",
+              "isMut": true,
               "isSigner": false
             },
             {
@@ -2996,7 +2996,7 @@ export const IDL: ExampleNativeTokenTransfers = {
           ]
         },
         {
-          "name": "payer",
+          "name": "rentPayer",
           "isMut": true,
           "isSigner": true
         },
@@ -3063,11 +3063,6 @@ export const IDL: ExampleNativeTokenTransfers = {
           "isSigner": false
         },
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
           "name": "mint",
           "isMut": true,
           "isSigner": false
@@ -3075,6 +3070,11 @@ export const IDL: ExampleNativeTokenTransfers = {
         {
           "name": "tokenAuthority",
           "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
           "isSigner": false
         },
         {
@@ -3107,11 +3107,6 @@ export const IDL: ExampleNativeTokenTransfers = {
               "isSigner": false
             },
             {
-              "name": "payer",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
               "name": "mint",
               "isMut": true,
               "isSigner": false
@@ -3119,6 +3114,11 @@ export const IDL: ExampleNativeTokenTransfers = {
             {
               "name": "tokenAuthority",
               "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "rentPayer",
+              "isMut": true,
               "isSigner": false
             },
             {

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -846,39 +846,49 @@ export type ExampleNativeTokenTransfers = {
       "name": "revertTokenAuthority",
       "accounts": [
         {
-          "name": "config",
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "rentPayer",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "pendingTokenAuthority",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "systemProgram",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "owner",
           "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "mint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rentPayer",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "pendingTokenAuthority",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "isSigner": true
         }
       ],
       "args": []
@@ -3120,39 +3130,49 @@ export const IDL: ExampleNativeTokenTransfers = {
       "name": "revertTokenAuthority",
       "accounts": [
         {
-          "name": "config",
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "mint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "rentPayer",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "pendingTokenAuthority",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "systemProgram",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "owner",
           "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "mint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rentPayer",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "pendingTokenAuthority",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "isSigner": true
         }
       ],
       "args": []

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -717,7 +717,7 @@ export namespace NTT {
     program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
     config: NttBindings.Config<IdlVersion>,
     args: {
-      payer: PublicKey;
+      rentPayer: PublicKey;
       owner: PublicKey;
       newAuthority: PublicKey;
     },
@@ -734,7 +734,7 @@ export namespace NTT {
           owner: args.owner,
           newAuthority: args.newAuthority,
         },
-        payer: args.payer,
+        rentPayer: args.rentPayer,
         pendingTokenAuthority: pdas.pendingTokenAuthority(),
         systemProgram: SystemProgram.programId,
       })

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -97,6 +97,8 @@ export namespace NTT {
       derivePda("outbox_rate_limit", programId);
     const tokenAuthority = (): PublicKey =>
       derivePda("token_authority", programId);
+    const pendingTokenAuthority = (): PublicKey =>
+      derivePda("pending_token_authority", programId);
     const peerAccount = (chain: Chain): PublicKey =>
       derivePda(["peer", chainToBytes(chain)], programId);
     const registeredTransceiver = (transceiver: PublicKey): PublicKey =>
@@ -131,6 +133,7 @@ export namespace NTT {
       inboxItemAccount,
       sessionAuthority,
       tokenAuthority,
+      pendingTokenAuthority,
       peerAccount,
       registeredTransceiver,
       lutAccount,
@@ -706,6 +709,34 @@ export namespace NTT {
       .accounts({
         config: pdas.configAccount(),
         newOwner: args.newOwner,
+      })
+      .instruction();
+  }
+
+  export async function createSetTokenAuthorityInstruction(
+    program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
+    config: NttBindings.Config<IdlVersion>,
+    args: {
+      payer: PublicKey;
+      owner: PublicKey;
+      newAuthority: PublicKey;
+    },
+    pdas?: Pdas
+  ) {
+    pdas = pdas ?? NTT.pdas(program.programId);
+    return await program.methods
+      .setTokenAuthority()
+      .accountsStrict({
+        common: {
+          config: pdas.configAccount(),
+          tokenAuthority: pdas.tokenAuthority(),
+          mint: config.mint,
+          owner: args.owner,
+          newAuthority: args.newAuthority,
+        },
+        payer: args.payer,
+        pendingTokenAuthority: pdas.pendingTokenAuthority(),
+        systemProgram: SystemProgram.programId,
       })
       .instruction();
   }

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -713,6 +713,27 @@ export namespace NTT {
       .instruction();
   }
 
+  export async function createAcceptTokenAuthorityInstruction(
+    program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
+    config: NttBindings.Config<IdlVersion>,
+    args: {
+      currentAuthority: PublicKey;
+    },
+    pdas?: Pdas
+  ) {
+    pdas = pdas ?? NTT.pdas(program.programId);
+    return await program.methods
+      .acceptTokenAuthority()
+      .accountsStrict({
+        config: pdas.configAccount(),
+        mint: config.mint,
+        tokenProgram: config.tokenProgram,
+        tokenAuthority: pdas.tokenAuthority(),
+        currentAuthority: args.currentAuthority,
+      })
+      .instruction();
+  }
+
   export async function createSetTokenAuthorityInstruction(
     program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
     config: NttBindings.Config<IdlVersion>,

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -254,7 +254,7 @@ export namespace NTT {
     pdas = pdas ?? NTT.pdas(program.programId);
 
     const limit = new BN(args.outboundLimit.toString());
-    return await program.methods
+    return program.methods
       .initialize({ chainId, limit: limit, mode })
       .accountsStrict({
         payer: args.payer,
@@ -361,7 +361,7 @@ export namespace NTT {
       }
     }
 
-    return await program.methods
+    return program.methods
       .initializeLut(new BN(slot))
       .accountsStrict({
         payer: args.payer,
@@ -704,7 +704,7 @@ export namespace NTT {
     pdas?: Pdas
   ) {
     pdas = pdas ?? NTT.pdas(program.programId);
-    return await program.methods
+    return program.methods
       .transferOwnership()
       .accounts({
         config: pdas.configAccount(),
@@ -722,7 +722,7 @@ export namespace NTT {
     pdas?: Pdas
   ) {
     pdas = pdas ?? NTT.pdas(program.programId);
-    return await program.methods
+    return program.methods
       .acceptTokenAuthority()
       .accountsStrict({
         config: pdas.configAccount(),
@@ -745,7 +745,7 @@ export namespace NTT {
     pdas?: Pdas
   ) {
     pdas = pdas ?? NTT.pdas(program.programId);
-    return await program.methods
+    return program.methods
       .setTokenAuthority()
       .accountsStrict({
         common: {
@@ -775,7 +775,7 @@ export namespace NTT {
     pdas?: Pdas
   ) {
     pdas = pdas ?? NTT.pdas(program.programId);
-    return await program.methods
+    return program.methods
       .setPeer({
         chainId: { id: toChainId(args.chain) },
         address: Array.from(args.address),
@@ -802,7 +802,7 @@ export namespace NTT {
     pdas?: Pdas
   ) {
     pdas = pdas ?? NTT.pdas(program.programId);
-    return await program.methods
+    return program.methods
       .setPaused(args.paused)
       .accountsStrict({
         owner: args.owner,
@@ -820,7 +820,7 @@ export namespace NTT {
     pdas?: Pdas
   ) {
     pdas = pdas ?? NTT.pdas(program.programId);
-    return await program.methods
+    return program.methods
       .setOutboundLimit({
         limit: args.limit,
       })
@@ -842,7 +842,7 @@ export namespace NTT {
     pdas?: Pdas
   ) {
     pdas = pdas ?? NTT.pdas(program.programId);
-    return await program.methods
+    return program.methods
       .setInboundLimit({
         chainId: { id: toChainId(args.chain) },
         limit: args.limit,
@@ -907,7 +907,7 @@ export namespace NTT {
     program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
     pdas: Pdas
   ): Promise<NttBindings.Config<IdlVersion>> {
-    return await program.account.config.fetch(pdas.configAccount());
+    return program.account.config.fetch(pdas.configAccount());
   }
 
   export async function getInboxItem(
@@ -915,7 +915,7 @@ export namespace NTT {
     fromChain: Chain,
     nttMessage: Ntt.Message
   ): Promise<NttBindings.InboxItem<IdlVersion>> {
-    return await program.account.inboxItem.fetch(
+    return program.account.inboxItem.fetch(
       NTT.pdas(program.programId).inboxItemAccount(fromChain, nttMessage)
     );
   }

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -762,6 +762,33 @@ export namespace NTT {
       .instruction();
   }
 
+  export async function createRevertTokenAuthorityInstruction(
+    program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
+    config: NttBindings.Config<IdlVersion>,
+    args: {
+      rentPayer: PublicKey;
+      owner: PublicKey;
+    },
+    pdas?: Pdas
+  ) {
+    pdas = pdas ?? NTT.pdas(program.programId);
+    return program.methods
+      .revertTokenAuthority()
+      .accountsStrict({
+        common: {
+          config: pdas.configAccount(),
+          mint: config.mint,
+          tokenAuthority: pdas.tokenAuthority(),
+          tokenProgram: config.tokenProgram,
+          systemProgram: SystemProgram.programId,
+          rentPayer: args.rentPayer,
+          pendingTokenAuthority: pdas.pendingTokenAuthority(),
+        },
+        owner: args.owner,
+      })
+      .instruction();
+  }
+
   export async function createSetPeerInstruction(
     program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
     args: {


### PR DESCRIPTION
This PR adds:
* Two ways to transfer out mint authority like `transfer_ownership`:
  * One step version: `set_token_authority_one_step_unchecked` ix
  * Two step version: `set_token_authority` and `claim_token_authority` ix (and `revert_token_authority` to reset authority back to `token_authority`)
* `createSetTokenAuthorityInstruction` helper function in `NTT` namespace
* Update IDL