### PR TITLE
cli: use finalized commitment level for solana program deploy

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1389,7 +1389,8 @@ async function deploySolana<N extends Network, C extends SolanaChains>(
             "--buffer", `buffer.json`,
             binary,
             "--keypair", payer,
-            "-u", ch.config.rpc
+            "-u", ch.config.rpc,
+            "--commitment", "finalized"
         ];
 
         if (priorityFee !== undefined) {


### PR DESCRIPTION
testing an alternate approach to #573. I think the test is simply failing because the deploy is using `confirmed` and the read is using `finalized` (or something like that). My hunch is that setting the deploy to `finalized` should incorporate the appropriate wait time.