### PR TITLE
EVM: make transferEntryPoint virtual

### DIFF
--- a/evm/src/NttManager/NttManager.sol
+++ b/evm/src/NttManager/NttManager.sol
@@ -383,7 +383,7 @@ contract NttManager is INttManager, RateLimiter, ManagerBase {
         bytes32 refundAddress,
         bool shouldQueue,
         bytes memory transceiverInstructions
-    ) internal returns (uint64) {
+    ) internal virtual returns (uint64) {
         if (amount == 0) {
             revert ZeroAmount();
         }


### PR DESCRIPTION
## Overview
This PR makes `_transferEntryPoint` function virtual in `NttManager` contract allowing more flexibility for integrators

## Changes
- Added `virtual` modifier to `_transferEntryPoint` function
- No changes to the existing function logic or behavior

## Motivation
- Ability to add custom logic
- Ability to remove unused code and save gas  

## Impact
- No breaking changes
- Backwards compatible
- No security implications as core logic remains unchanged

## Testing
- Existing tests remain unchanged and passing