### PR TITLE
solana: Add `set_threshold` ix

### DIFF
--- a/solana/programs/example-native-token-transfers/src/bitmap.rs
+++ b/solana/programs/example-native-token-transfers/src/bitmap.rs
@@ -48,8 +48,11 @@ impl Bitmap {
             .expect("Bitmap length must not exceed the bounds of u8")
     }
 
-    pub fn len(self) -> usize {
-        BM::<128>::from_value(self.map).len()
+    pub fn len(self) -> u8 {
+        BM::<128>::from_value(self.map)
+            .len()
+            .try_into()
+            .expect("Bitmap length must not exceed the bounds of u8")
     }
 
     pub fn is_empty(self) -> bool {

--- a/solana/programs/example-native-token-transfers/src/error.rs
+++ b/solana/programs/example-native-token-transfers/src/error.rs
@@ -63,6 +63,8 @@ pub enum NTTError {
     InvalidMultisig,
     #[msg("ThresholdTooHigh")]
     ThresholdTooHigh,
+    #[msg("InvalidTransceiverProgram")]
+    InvalidTransceiverProgram,
 }
 
 impl From<ScalingError> for NTTError {

--- a/solana/programs/example-native-token-transfers/src/error.rs
+++ b/solana/programs/example-native-token-transfers/src/error.rs
@@ -61,6 +61,8 @@ pub enum NTTError {
     IncorrectRentPayer,
     #[msg("InvalidMultisig")]
     InvalidMultisig,
+    #[msg("ThresholdTooHigh")]
+    ThresholdTooHigh,
 }
 
 impl From<ScalingError> for NTTError {

--- a/solana/programs/example-native-token-transfers/src/instructions/initialize.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/initialize.rs
@@ -155,7 +155,7 @@ fn initialize_config_and_rate_limit(
         pending_owner: None,
         paused: false,
         next_transceiver_id: 0,
-        // NOTE: can't be changed for now
+        // NOTE: can be changed via `set_threshold` ix
         threshold: 1,
         enabled_transceivers: Bitmap::new(),
         custody: common.custody.key(),

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -206,6 +206,10 @@ pub mod example_native_token_transfers {
         instructions::mark_outbox_item_as_released(ctx)
     }
 
+    pub fn set_threshold(ctx: Context<SetThreshold>, threshold: u8) -> Result<()> {
+        instructions::set_threshold(ctx, threshold)
+    }
+
     // standalone transceiver stuff
 
     pub fn set_wormhole_peer(

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -188,6 +188,10 @@ pub mod example_native_token_transfers {
         instructions::register_transceiver(ctx)
     }
 
+    pub fn deregister_transceiver(ctx: Context<DeregisterTransceiver>) -> Result<()> {
+        instructions::deregister_transceiver(ctx)
+    }
+
     pub fn set_outbound_limit(
         ctx: Context<SetOutboundLimit>,
         args: SetOutboundLimitArgs,

--- a/solana/programs/example-native-token-transfers/tests/admin.rs
+++ b/solana/programs/example-native-token-transfers/tests/admin.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "test-sbf")]
+#![feature(type_changing_struct_update)]
+
+use example_native_token_transfers::error::NTTError;
+use ntt_messages::mode::Mode;
+use solana_program_test::*;
+use solana_sdk::{instruction::InstructionError, signer::Signer, transaction::TransactionError};
+
+use crate::{
+    common::{setup::setup, submit::Submittable},
+    sdk::instructions::admin::{set_threshold, SetThreshold},
+};
+
+pub mod common;
+pub mod sdk;
+
+#[tokio::test]
+async fn test_zero_threshold() {
+    let (mut ctx, test_data) = setup(Mode::Locking).await;
+
+    let err = set_threshold(
+        &test_data.ntt,
+        SetThreshold {
+            owner: test_data.program_owner.pubkey(),
+        },
+        0,
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap_err();
+    assert_eq!(
+        err.unwrap(),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(NTTError::ZeroThreshold.into())
+        )
+    );
+}
+
+#[tokio::test]
+async fn test_threshold_too_high() {
+    let (mut ctx, test_data) = setup(Mode::Burning).await;
+
+    let err = set_threshold(
+        &test_data.ntt,
+        SetThreshold {
+            owner: test_data.program_owner.pubkey(),
+        },
+        2,
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap_err();
+    assert_eq!(
+        err.unwrap(),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(NTTError::ThresholdTooHigh.into())
+        )
+    );
+}

--- a/solana/programs/example-native-token-transfers/tests/admin.rs
+++ b/solana/programs/example-native-token-transfers/tests/admin.rs
@@ -1,7 +1,10 @@
 #![cfg(feature = "test-sbf")]
 #![feature(type_changing_struct_update)]
 
-use example_native_token_transfers::{config::Config, error::NTTError};
+use anchor_lang::{prelude::Pubkey, system_program::System, Id};
+use example_native_token_transfers::{
+    config::Config, error::NTTError, registered_transceiver::RegisteredTransceiver,
+};
 use ntt_messages::mode::Mode;
 use solana_program_test::*;
 use solana_sdk::{instruction::InstructionError, signer::Signer, transaction::TransactionError};
@@ -30,6 +33,47 @@ async fn assert_threshold(
     assert_eq!(config_account.threshold, expected_threshold);
 }
 
+async fn assert_transceiver_id(
+    ctx: &mut ProgramTestContext,
+    test_data: &TestData,
+    transceiver: &Pubkey,
+    expected_id: u8,
+) {
+    let registered_transceiver_account: RegisteredTransceiver = ctx
+        .get_account_data_anchor(test_data.ntt.registered_transceiver(transceiver))
+        .await;
+    assert_eq!(
+        registered_transceiver_account.transceiver_address,
+        *transceiver
+    );
+    assert_eq!(registered_transceiver_account.id, expected_id);
+}
+
+#[tokio::test]
+async fn test_invalid_transceiver() {
+    let (mut ctx, test_data) = setup(Mode::Locking).await;
+
+    // try registering system program
+    let err = register_transceiver(
+        &test_data.ntt,
+        RegisterTransceiver {
+            payer: ctx.payer.pubkey(),
+            owner: test_data.program_owner.pubkey(),
+            transceiver: System::id(),
+        },
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap_err();
+    assert_eq!(
+        err.unwrap(),
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(NTTError::InvalidTransceiverProgram.into())
+        )
+    );
+}
+
 #[tokio::test]
 async fn test_reregister_all_transceivers() {
     let (mut ctx, test_data) = setup(Mode::Locking).await;
@@ -43,7 +87,7 @@ async fn test_reregister_all_transceivers() {
     let num_dummy_transceivers: u8 = dummy_transceivers.len().try_into().unwrap();
 
     // register dummy transceivers
-    for transceiver in &dummy_transceivers {
+    for (idx, transceiver) in dummy_transceivers.iter().enumerate() {
         register_transceiver(
             &test_data.ntt,
             RegisterTransceiver {
@@ -55,6 +99,7 @@ async fn test_reregister_all_transceivers() {
         .submit_with_signers(&[&test_data.program_owner], &mut ctx)
         .await
         .unwrap();
+        assert_transceiver_id(&mut ctx, &test_data, transceiver, idx as u8 + 1).await;
     }
 
     // set threshold = 1 (for baked-in transceiver) + num_dummy_transceivers
@@ -98,7 +143,7 @@ async fn test_reregister_all_transceivers() {
     assert_threshold(&mut ctx, &test_data, 1).await;
 
     // reregister dummy transceiver
-    for transceiver in &dummy_transceivers {
+    for (idx, transceiver) in dummy_transceivers.iter().enumerate() {
         register_transceiver(
             &test_data.ntt,
             RegisterTransceiver {
@@ -110,6 +155,7 @@ async fn test_reregister_all_transceivers() {
         .submit_with_signers(&[&test_data.program_owner], &mut ctx)
         .await
         .unwrap();
+        assert_transceiver_id(&mut ctx, &test_data, transceiver, idx as u8 + 1).await;
         assert_threshold(&mut ctx, &test_data, 1).await;
     }
 
@@ -125,6 +171,7 @@ async fn test_reregister_all_transceivers() {
     .submit_with_signers(&[&test_data.program_owner], &mut ctx)
     .await
     .unwrap();
+    assert_transceiver_id(&mut ctx, &test_data, &example_native_token_transfers::ID, 0).await;
     assert_threshold(&mut ctx, &test_data, 1).await;
 }
 

--- a/solana/programs/example-native-token-transfers/tests/admin.rs
+++ b/solana/programs/example-native-token-transfers/tests/admin.rs
@@ -1,18 +1,118 @@
 #![cfg(feature = "test-sbf")]
 #![feature(type_changing_struct_update)]
 
-use example_native_token_transfers::error::NTTError;
+use example_native_token_transfers::{config::Config, error::NTTError};
 use ntt_messages::mode::Mode;
 use solana_program_test::*;
 use solana_sdk::{instruction::InstructionError, signer::Signer, transaction::TransactionError};
 
 use crate::{
-    common::{setup::setup, submit::Submittable},
-    sdk::instructions::admin::{set_threshold, SetThreshold},
+    common::{
+        query::GetAccountDataAnchor,
+        setup::{setup, TestData},
+        submit::Submittable,
+    },
+    sdk::instructions::admin::{
+        deregister_transceiver, register_transceiver, set_threshold, DeregisterTransceiver,
+        RegisterTransceiver, SetThreshold,
+    },
 };
 
 pub mod common;
 pub mod sdk;
+
+async fn assert_threshold(
+    ctx: &mut ProgramTestContext,
+    test_data: &TestData,
+    expected_threshold: u8,
+) {
+    let config_account: Config = ctx.get_account_data_anchor(test_data.ntt.config()).await;
+    assert_eq!(config_account.threshold, expected_threshold);
+}
+
+#[tokio::test]
+async fn test_reregister_all_transceivers() {
+    let (mut ctx, test_data) = setup(Mode::Locking).await;
+
+    // register ntt_transceiver
+    register_transceiver(
+        &test_data.ntt,
+        RegisterTransceiver {
+            payer: ctx.payer.pubkey(),
+            owner: test_data.program_owner.pubkey(),
+            transceiver: ntt_transceiver::ID,
+        },
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap();
+
+    // set threshold to 2
+    set_threshold(
+        &test_data.ntt,
+        SetThreshold {
+            owner: test_data.program_owner.pubkey(),
+        },
+        2,
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap();
+
+    // deregister ntt_transceiver
+    deregister_transceiver(
+        &test_data.ntt,
+        DeregisterTransceiver {
+            owner: test_data.program_owner.pubkey(),
+            transceiver: ntt_transceiver::ID,
+        },
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap();
+    assert_threshold(&mut ctx, &test_data, 1).await;
+
+    // deregister baked-in transceiver
+    deregister_transceiver(
+        &test_data.ntt,
+        DeregisterTransceiver {
+            owner: test_data.program_owner.pubkey(),
+            transceiver: example_native_token_transfers::ID,
+        },
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap();
+    assert_threshold(&mut ctx, &test_data, 1).await;
+
+    // reregister ntt_transceiver
+    register_transceiver(
+        &test_data.ntt,
+        RegisterTransceiver {
+            payer: ctx.payer.pubkey(),
+            owner: test_data.program_owner.pubkey(),
+            transceiver: ntt_transceiver::ID,
+        },
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap();
+    assert_threshold(&mut ctx, &test_data, 1).await;
+
+    // reregister baked-in transceiver
+    register_transceiver(
+        &test_data.ntt,
+        RegisterTransceiver {
+            payer: ctx.payer.pubkey(),
+            owner: test_data.program_owner.pubkey(),
+            transceiver: example_native_token_transfers::ID,
+        },
+    )
+    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
+    .await
+    .unwrap();
+    assert_threshold(&mut ctx, &test_data, 1).await;
+}
 
 #[tokio::test]
 async fn test_zero_threshold() {

--- a/solana/programs/example-native-token-transfers/tests/sdk/instructions/admin.rs
+++ b/solana/programs/example-native-token-transfers/tests/sdk/instructions/admin.rs
@@ -74,6 +74,28 @@ pub fn register_transceiver(ntt: &NTT, accounts: RegisterTransceiver) -> Instruc
     }
 }
 
+pub struct DeregisterTransceiver {
+    pub owner: Pubkey,
+    pub transceiver: Pubkey,
+}
+
+pub fn deregister_transceiver(ntt: &NTT, accounts: DeregisterTransceiver) -> Instruction {
+    let data = example_native_token_transfers::instruction::DeregisterTransceiver {};
+
+    let accounts = example_native_token_transfers::accounts::DeregisterTransceiver {
+        config: ntt.config(),
+        owner: accounts.owner,
+        transceiver: accounts.transceiver,
+        registered_transceiver: ntt.registered_transceiver(&accounts.transceiver),
+    };
+
+    Instruction {
+        program_id: ntt.program,
+        accounts: accounts.to_account_metas(None),
+        data: data.data(),
+    }
+}
+
 pub struct SetThreshold {
     pub owner: Pubkey,
 }

--- a/solana/programs/example-native-token-transfers/tests/sdk/instructions/admin.rs
+++ b/solana/programs/example-native-token-transfers/tests/sdk/instructions/admin.rs
@@ -73,3 +73,22 @@ pub fn register_transceiver(ntt: &NTT, accounts: RegisterTransceiver) -> Instruc
         data: data.data(),
     }
 }
+
+pub struct SetThreshold {
+    pub owner: Pubkey,
+}
+
+pub fn set_threshold(ntt: &NTT, accounts: SetThreshold, threshold: u8) -> Instruction {
+    let data = example_native_token_transfers::instruction::SetThreshold { threshold };
+
+    let accounts = example_native_token_transfers::accounts::SetThreshold {
+        config: ntt.config(),
+        owner: accounts.owner,
+    };
+
+    Instruction {
+        program_id: example_native_token_transfers::ID,
+        accounts: accounts.to_account_metas(None),
+        data: data.data(),
+    }
+}

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -1351,6 +1351,35 @@
       "args": []
     },
     {
+      "name": "deregisterTransceiver",
+      "accounts": [
+        {
+          "name": "config",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "transceiver",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "used here that wraps the Transceiver account type."
+          ]
+        },
+        {
+          "name": "registeredTransceiver",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "setOutboundLimit",
       "accounts": [
         {
@@ -1437,6 +1466,27 @@
       ],
       "args": [],
       "returns": "bool"
+    },
+    {
+      "name": "setThreshold",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "config",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "threshold",
+          "type": "u8"
+        }
+      ]
     },
     {
       "name": "setWormholePeer",
@@ -2587,6 +2637,16 @@
       "code": 6027,
       "name": "InvalidMultisig",
       "msg": "InvalidMultisig"
+    },
+    {
+      "code": 6028,
+      "name": "ThresholdTooHigh",
+      "msg": "ThresholdTooHigh"
+    },
+    {
+      "code": 6029,
+      "name": "InvalidTransceiverProgram",
+      "msg": "InvalidTransceiverProgram"
     }
   ]
 }

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -1351,6 +1351,35 @@ export type ExampleNativeTokenTransfers = {
       "args": []
     },
     {
+      "name": "deregisterTransceiver",
+      "accounts": [
+        {
+          "name": "config",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "transceiver",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "used here that wraps the Transceiver account type."
+          ]
+        },
+        {
+          "name": "registeredTransceiver",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "setOutboundLimit",
       "accounts": [
         {
@@ -1437,6 +1466,27 @@ export type ExampleNativeTokenTransfers = {
       ],
       "args": [],
       "returns": "bool"
+    },
+    {
+      "name": "setThreshold",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "config",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "threshold",
+          "type": "u8"
+        }
+      ]
     },
     {
       "name": "setWormholePeer",
@@ -2587,6 +2637,16 @@ export type ExampleNativeTokenTransfers = {
       "code": 6027,
       "name": "InvalidMultisig",
       "msg": "InvalidMultisig"
+    },
+    {
+      "code": 6028,
+      "name": "ThresholdTooHigh",
+      "msg": "ThresholdTooHigh"
+    },
+    {
+      "code": 6029,
+      "name": "InvalidTransceiverProgram",
+      "msg": "InvalidTransceiverProgram"
     }
   ]
 }
@@ -3943,6 +4003,35 @@ export const IDL: ExampleNativeTokenTransfers = {
       "args": []
     },
     {
+      "name": "deregisterTransceiver",
+      "accounts": [
+        {
+          "name": "config",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "transceiver",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "used here that wraps the Transceiver account type."
+          ]
+        },
+        {
+          "name": "registeredTransceiver",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "setOutboundLimit",
       "accounts": [
         {
@@ -4029,6 +4118,27 @@ export const IDL: ExampleNativeTokenTransfers = {
       ],
       "args": [],
       "returns": "bool"
+    },
+    {
+      "name": "setThreshold",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "config",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "threshold",
+          "type": "u8"
+        }
+      ]
     },
     {
       "name": "setWormholePeer",
@@ -5179,6 +5289,16 @@ export const IDL: ExampleNativeTokenTransfers = {
       "code": 6027,
       "name": "InvalidMultisig",
       "msg": "InvalidMultisig"
+    },
+    {
+      "code": 6028,
+      "name": "ThresholdTooHigh",
+      "msg": "ThresholdTooHigh"
+    },
+    {
+      "code": 6029,
+      "name": "InvalidTransceiverProgram",
+      "msg": "InvalidTransceiverProgram"
     }
   ]
 }

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -1103,6 +1103,24 @@ export namespace NTT {
       .instruction();
   }
 
+  export async function createSetThresholdInstruction(
+    program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
+    args: {
+      owner: PublicKey;
+      threshold: number;
+    },
+    pdas?: Pdas
+  ) {
+    pdas = pdas ?? NTT.pdas(program.programId);
+    return program.methods
+      .setThreshold(args.threshold)
+      .accountsStrict({
+        owner: args.owner,
+        config: pdas.configAccount(),
+      })
+      .instruction();
+  }
+
   export async function createSetOutboundLimitInstruction(
     program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
     args: {

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -759,6 +759,28 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
       .instruction();
   }
 
+  async createDeregisterTransceiverIx(
+    ix: number,
+    owner: web3.PublicKey
+  ): Promise<web3.TransactionInstruction> {
+    const transceiver = await this.getTransceiver(ix);
+    if (!transceiver) {
+      throw new Error(`Transceiver not found`);
+    }
+    const transceiverProgramId = transceiver.programId;
+
+    return this.program.methods
+      .deregisterTransceiver()
+      .accountsStrict({
+        owner,
+        config: this.pdas.configAccount(),
+        transceiver: transceiverProgramId,
+        registeredTransceiver:
+          this.pdas.registeredTransceiver(transceiverProgramId),
+      })
+      .instruction();
+  }
+
   async *setWormholeTransceiverPeer(
     peer: ChainAddress,
     payer: AccountAddress<C>


### PR DESCRIPTION
Currently there is no way to update the NTT manager `threshold` (# of transceivers that must attest to a transfer before it is accepted) - it defaults to 1 - or deregister a transceiver. With multi-transceiver support, having a way to manage transceivers and their threshold is essential.

This PR adds:
* `set_threshold` ix to update the threshold (`0 < threshold <= # of enabled transceivers`)
* `deregister_transceiver` ix to deregister (disable transceiver in enabled transceiver bitmap):
   * Also decrements threshold (down to minimum 1) if # of enabled transceivers < threshold 
* Update `register_transceiver` ix to also act as re-enable:
   * If `RegisteredTransceiver` account is init for the first time, assign new id
   * Otherwise, reuse old id
* Rust tests to verify edge cases
* `createSetThresholdInstruction` and `createDeregisterTransceiverIx` TS helpers as a part of NTT namespace and `SolanaNtt` class respectively
* Update IDL