### PR TITLE
ci: Fix `call didn't revert at a lower depth than cheatcode call depth` forge error in EVM tests

### DIFF
--- a/evm/test/TrimmedAmount.t.sol
+++ b/evm/test/TrimmedAmount.t.sol
@@ -67,6 +67,7 @@ contract TrimmingTest is Test {
         }
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testAddOperatorDecimalsNotEqualRevert() public {
         uint8 decimals = 18;
         uint8 decimalsOther = 3;
@@ -134,6 +135,7 @@ contract TrimmingTest is Test {
         }
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSubOperatorOverflow() public {
         uint8[2] memory decimals = [18, 3];
 
@@ -263,6 +265,7 @@ contract TrimmingTest is Test {
         assertEq(expectedTrimmedSub.getDecimals(), trimmedSub.getDecimals());
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testFuzz_SubOperatorWillOverflow(
         uint8 decimals,
         uint256 amtLeft,


### PR DESCRIPTION
With Foundry v1 release, some forge tests have been failing with this error. 
This PR fixes this by adding `/// forge-config: default.allow_internal_expect_revert = true` above the test function.



See https://book.getfoundry.sh/cheatcodes/expect-revert#description for reference:
> Selectively by using an inline configuration entry where it is DEEMED SAFE:
> Add `/// forge-config: default.allow_internal_expect_revert = true` above the test function.