### PR TITLE
solana: Remove `*_multisig` instruction variants

### DIFF
--- a/solana/programs/example-native-token-transfers/src/instructions/admin/transfer_token_authority.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin/transfer_token_authority.rs
@@ -349,10 +349,10 @@ fn claim_from_token_authority<'info>(
 ) -> Result<()> {
     token_interface::set_authority(
         CpiContext::new_with_signer(
-            token_program.to_account_info(),
+            token_program,
             token_interface::SetAuthority {
-                account_or_mint: mint.to_account_info(),
-                current_authority: token_authority.to_account_info(),
+                account_or_mint: mint,
+                current_authority: token_authority,
             },
             &[&[crate::TOKEN_AUTHORITY_SEED, &[token_authority_bump]]],
         ),

--- a/solana/programs/example-native-token-transfers/src/instructions/release_inbound.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/release_inbound.rs
@@ -75,8 +75,8 @@ pub struct ReleaseInboundMint<'info> {
 }
 
 /// Release an inbound transfer and mint the tokens to the recipient.
-/// When `revert_on_error` is true, the transaction will revert if the
-/// release timestamp has not been reached. When `revert_on_error` is false, the
+/// When `revert_on_delay` is true, the transaction will revert if the
+/// release timestamp has not been reached. When `revert_on_delay` is false, the
 /// transaction succeeds, but the minting is not performed.
 /// Setting this flag to `false` is useful when bundling this instruction
 /// together with [`crate::instructions::redeem`] in a transaction, so that the minting
@@ -206,8 +206,8 @@ pub struct ReleaseInboundUnlock<'info> {
 }
 
 /// Release an inbound transfer and unlock the tokens to the recipient.
-/// When `revert_on_error` is true, the transaction will revert if the
-/// release timestamp has not been reached. When `revert_on_error` is false, the
+/// When `revert_on_delay` is true, the transaction will revert if the
+/// release timestamp has not been reached. When `revert_on_delay` is false, the
 /// transaction succeeds, but the unlocking is not performed.
 /// Setting this flag to `false` is useful when bundling this instruction
 /// together with [`crate::instructions::redeem`], so that the unlocking

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -76,13 +76,6 @@ pub mod example_native_token_transfers {
         instructions::initialize(ctx, args)
     }
 
-    pub fn initialize_multisig(
-        ctx: Context<InitializeMultisig>,
-        args: InitializeArgs,
-    ) -> Result<()> {
-        instructions::initialize_multisig(ctx, args)
-    }
-
     pub fn initialize_lut(ctx: Context<InitializeLUT>, recent_slot: u64) -> Result<()> {
         instructions::initialize_lut(ctx, recent_slot)
     }

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -109,13 +109,6 @@ pub mod example_native_token_transfers {
         instructions::release_inbound_mint(ctx, args)
     }
 
-    pub fn release_inbound_mint_multisig<'info>(
-        ctx: Context<'_, '_, '_, 'info, ReleaseInboundMintMultisig<'info>>,
-        args: ReleaseInboundArgs,
-    ) -> Result<()> {
-        instructions::release_inbound_mint_multisig(ctx, args)
-    }
-
     pub fn release_inbound_unlock<'info>(
         ctx: Context<'_, '_, '_, 'info, ReleaseInboundUnlock<'info>>,
         args: ReleaseInboundArgs,

--- a/solana/programs/example-native-token-transfers/src/queue/inbox.rs
+++ b/solana/programs/example-native-token-transfers/src/queue/inbox.rs
@@ -51,7 +51,7 @@ impl InboxItem {
         let now = current_timestamp();
 
         match self.release_status {
-            ReleaseStatus::NotApproved => Err(NTTError::TransferNotApproved.into()),
+            ReleaseStatus::NotApproved => Ok(false),
             ReleaseStatus::ReleaseAfter(release_timestamp) => {
                 if release_timestamp > now {
                     return Ok(false);

--- a/solana/programs/example-native-token-transfers/src/queue/inbox.rs
+++ b/solana/programs/example-native-token-transfers/src/queue/inbox.rs
@@ -35,17 +35,15 @@ impl InboxItem {
     pub const SEED_PREFIX: &'static [u8] = b"inbox_item";
 
     /// Attempt to release the transfer.
-    /// If the inbox item status is [`ReleaseStatus::ReleaseAfter`], this function returns true if the current timestamp
-    /// is newer than the one stored in the release status. If the timestamp is in the future,
-    /// returns false.
+    ///
+    /// * If the inbox item status is [`ReleaseStatus::ReleaseAfter`], this function returns true if the current timestamp
+    /// is newer than the one stored in the release status. If the timestamp is in the future, returns false.
+    /// * If the inbox item status is [`ReleaseStatus::NotApproved`], this function returns false.
     ///
     /// # Errors
     ///
-    /// Returns errors when the item cannot be released, i.e. when its status is not
-    /// `ReleaseAfter`:
-    /// - returns [`NTTError::TransferNotApproved`] if [`ReleaseStatus::NotApproved`]
-    /// - returns [`NTTError::TransferAlreadyRedeemed`] if [`ReleaseStatus::Released`]. This is
-    /// important to prevent a single transfer from being redeemed multiple times, which would
+    /// Returns [`NTTError::TransferAlreadyRedeemed`] if the inbox item status is [`ReleaseStatus::Released`].
+    /// This is important to prevent a single transfer from being redeemed multiple times, which would
     /// result in minting arbitrary amounts of the token.
     pub fn try_release(&mut self) -> Result<bool> {
         let now = current_timestamp();

--- a/solana/programs/example-native-token-transfers/tests/common/setup.rs
+++ b/solana/programs/example-native-token-transfers/tests/common/setup.rs
@@ -179,6 +179,7 @@ pub async fn setup_ntt_with_token_program_id(
             payer: ctx.payer.pubkey(),
             deployer: test_data.program_owner.pubkey(),
             mint: test_data.mint,
+            multisig_token_authority: None,
         },
         InitializeArgs {
             // TODO: use sdk

--- a/solana/programs/example-native-token-transfers/tests/sdk/instructions/initialize.rs
+++ b/solana/programs/example-native-token-transfers/tests/sdk/instructions/initialize.rs
@@ -10,6 +10,7 @@ pub struct Initialize {
     pub payer: Pubkey,
     pub deployer: Pubkey,
     pub mint: Pubkey,
+    pub multisig_token_authority: Option<Pubkey>,
 }
 
 pub fn initialize(ntt: &NTT, accounts: Initialize, args: InitializeArgs) -> Instruction {
@@ -33,6 +34,7 @@ pub fn initialize_with_token_program_id(
         mint: accounts.mint,
         rate_limit: ntt.outbox_rate_limit(),
         token_authority: ntt.token_authority(),
+        multisig_token_authority: accounts.multisig_token_authority,
         custody: ntt.custody_with_token_program_id(&accounts.mint, token_program_id),
         token_program: *token_program_id,
         associated_token_program: AssociatedToken::id(),

--- a/solana/tests/anchor.test.ts
+++ b/solana/tests/anchor.test.ts
@@ -176,7 +176,7 @@ describe("example-native-token-transfers", () => {
         mint: testMint.address,
         outboundLimit: 1_000_000n,
         mode: "burning",
-        multisig: multisigTokenAuthority,
+        multisigTokenAuthority,
       });
       await signSendWait(ctx, initTxs, signer);
 

--- a/solana/tests/anchor.test.ts
+++ b/solana/tests/anchor.test.ts
@@ -504,7 +504,7 @@ describe("example-native-token-transfers", () => {
       const published = emitter.publishMessage(0, serialized, 200);
       const rawVaa = guardians.addSignatures(published, [0]);
       const vaa = deserialize("Ntt:WormholeTransfer", serialize(rawVaa));
-      const redeemTxs = ntt.redeem([vaa], sender, multisigTokenAuthority);
+      const redeemTxs = ntt.redeem([vaa], sender);
       await signSendWait(ctx, redeemTxs, signer);
 
       assert.bn(await testDummyTransferHook.counter.value()).equal(2);

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -48,6 +48,12 @@
           ]
         },
         {
+          "name": "multisigTokenAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
           "name": "custody",
           "isMut": true,
           "isSigner": false,
@@ -77,104 +83,6 @@
         },
         {
           "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": "InitializeArgs"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeMultisig",
-      "accounts": [
-        {
-          "name": "common",
-          "accounts": [
-            {
-              "name": "payer",
-              "isMut": true,
-              "isSigner": true
-            },
-            {
-              "name": "deployer",
-              "isMut": false,
-              "isSigner": true
-            },
-            {
-              "name": "programData",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "config",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "mint",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "rateLimit",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenAuthority",
-              "isMut": false,
-              "isSigner": false,
-              "docs": [
-                "In any case, this function is used to set the Config and initialize the program so we",
-                "assume the caller of this function will have total control over the program.",
-                "",
-                "TODO: Using `UncheckedAccount` here leads to \"Access violation in stack frame ...\".",
-                "Could refactor code to use `Box<_>` to reduce stack size."
-              ]
-            },
-            {
-              "name": "custody",
-              "isMut": true,
-              "isSigner": false,
-              "docs": [
-                "The custody account that holds tokens in locking mode and temporarily",
-                "holds tokens in burning mode.",
-                "function if the token account has already been created."
-              ]
-            },
-            {
-              "name": "tokenProgram",
-              "isMut": false,
-              "isSigner": false,
-              "docs": [
-                "associated token account for the given mint."
-              ]
-            },
-            {
-              "name": "associatedTokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "bpfLoaderUpgradeableProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "systemProgram",
-              "isMut": false,
-              "isSigner": false
-            }
-          ]
-        },
-        {
-          "name": "multisig",
           "isMut": false,
           "isSigner": false
         }
@@ -637,77 +545,12 @@
               "isSigner": false
             }
           ]
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": "ReleaseInboundArgs"
-          }
-        }
-      ]
-    },
-    {
-      "name": "releaseInboundMintMultisig",
-      "accounts": [
-        {
-          "name": "common",
-          "accounts": [
-            {
-              "name": "payer",
-              "isMut": true,
-              "isSigner": true
-            },
-            {
-              "name": "config",
-              "accounts": [
-                {
-                  "name": "config",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
-              "name": "inboxItem",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "recipient",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenAuthority",
-              "isMut": false,
-              "isSigner": false,
-              "docs": [
-                "CHECK The seeds constraint ensures that this is the correct address"
-              ]
-            },
-            {
-              "name": "mint",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "custody",
-              "isMut": true,
-              "isSigner": false
-            }
-          ]
         },
         {
-          "name": "multisig",
+          "name": "multisigTokenAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "args": [

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -2129,7 +2129,7 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "revertOnDelay",
+            "name": "revertWhenNotReady",
             "type": "bool"
           }
         ]

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -48,6 +48,12 @@ export type ExampleNativeTokenTransfers = {
           ]
         },
         {
+          "name": "multisigTokenAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
           "name": "custody",
           "isMut": true,
           "isSigner": false,
@@ -77,104 +83,6 @@ export type ExampleNativeTokenTransfers = {
         },
         {
           "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": "InitializeArgs"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeMultisig",
-      "accounts": [
-        {
-          "name": "common",
-          "accounts": [
-            {
-              "name": "payer",
-              "isMut": true,
-              "isSigner": true
-            },
-            {
-              "name": "deployer",
-              "isMut": false,
-              "isSigner": true
-            },
-            {
-              "name": "programData",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "config",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "mint",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "rateLimit",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenAuthority",
-              "isMut": false,
-              "isSigner": false,
-              "docs": [
-                "In any case, this function is used to set the Config and initialize the program so we",
-                "assume the caller of this function will have total control over the program.",
-                "",
-                "TODO: Using `UncheckedAccount` here leads to \"Access violation in stack frame ...\".",
-                "Could refactor code to use `Box<_>` to reduce stack size."
-              ]
-            },
-            {
-              "name": "custody",
-              "isMut": true,
-              "isSigner": false,
-              "docs": [
-                "The custody account that holds tokens in locking mode and temporarily",
-                "holds tokens in burning mode.",
-                "function if the token account has already been created."
-              ]
-            },
-            {
-              "name": "tokenProgram",
-              "isMut": false,
-              "isSigner": false,
-              "docs": [
-                "associated token account for the given mint."
-              ]
-            },
-            {
-              "name": "associatedTokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "bpfLoaderUpgradeableProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "systemProgram",
-              "isMut": false,
-              "isSigner": false
-            }
-          ]
-        },
-        {
-          "name": "multisig",
           "isMut": false,
           "isSigner": false
         }
@@ -637,77 +545,12 @@ export type ExampleNativeTokenTransfers = {
               "isSigner": false
             }
           ]
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": "ReleaseInboundArgs"
-          }
-        }
-      ]
-    },
-    {
-      "name": "releaseInboundMintMultisig",
-      "accounts": [
-        {
-          "name": "common",
-          "accounts": [
-            {
-              "name": "payer",
-              "isMut": true,
-              "isSigner": true
-            },
-            {
-              "name": "config",
-              "accounts": [
-                {
-                  "name": "config",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
-              "name": "inboxItem",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "recipient",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenAuthority",
-              "isMut": false,
-              "isSigner": false,
-              "docs": [
-                "CHECK The seeds constraint ensures that this is the correct address"
-              ]
-            },
-            {
-              "name": "mint",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "custody",
-              "isMut": true,
-              "isSigner": false
-            }
-          ]
         },
         {
-          "name": "multisig",
+          "name": "multisigTokenAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "args": [
@@ -2700,6 +2543,12 @@ export const IDL: ExampleNativeTokenTransfers = {
           ]
         },
         {
+          "name": "multisigTokenAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
           "name": "custody",
           "isMut": true,
           "isSigner": false,
@@ -2729,104 +2578,6 @@ export const IDL: ExampleNativeTokenTransfers = {
         },
         {
           "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": "InitializeArgs"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeMultisig",
-      "accounts": [
-        {
-          "name": "common",
-          "accounts": [
-            {
-              "name": "payer",
-              "isMut": true,
-              "isSigner": true
-            },
-            {
-              "name": "deployer",
-              "isMut": false,
-              "isSigner": true
-            },
-            {
-              "name": "programData",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "config",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "mint",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "rateLimit",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenAuthority",
-              "isMut": false,
-              "isSigner": false,
-              "docs": [
-                "In any case, this function is used to set the Config and initialize the program so we",
-                "assume the caller of this function will have total control over the program.",
-                "",
-                "TODO: Using `UncheckedAccount` here leads to \"Access violation in stack frame ...\".",
-                "Could refactor code to use `Box<_>` to reduce stack size."
-              ]
-            },
-            {
-              "name": "custody",
-              "isMut": true,
-              "isSigner": false,
-              "docs": [
-                "The custody account that holds tokens in locking mode and temporarily",
-                "holds tokens in burning mode.",
-                "function if the token account has already been created."
-              ]
-            },
-            {
-              "name": "tokenProgram",
-              "isMut": false,
-              "isSigner": false,
-              "docs": [
-                "associated token account for the given mint."
-              ]
-            },
-            {
-              "name": "associatedTokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "bpfLoaderUpgradeableProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "systemProgram",
-              "isMut": false,
-              "isSigner": false
-            }
-          ]
-        },
-        {
-          "name": "multisig",
           "isMut": false,
           "isSigner": false
         }
@@ -3289,77 +3040,12 @@ export const IDL: ExampleNativeTokenTransfers = {
               "isSigner": false
             }
           ]
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": "ReleaseInboundArgs"
-          }
-        }
-      ]
-    },
-    {
-      "name": "releaseInboundMintMultisig",
-      "accounts": [
-        {
-          "name": "common",
-          "accounts": [
-            {
-              "name": "payer",
-              "isMut": true,
-              "isSigner": true
-            },
-            {
-              "name": "config",
-              "accounts": [
-                {
-                  "name": "config",
-                  "isMut": false,
-                  "isSigner": false
-                }
-              ]
-            },
-            {
-              "name": "inboxItem",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "recipient",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenAuthority",
-              "isMut": false,
-              "isSigner": false,
-              "docs": [
-                "CHECK The seeds constraint ensures that this is the correct address"
-              ]
-            },
-            {
-              "name": "mint",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "custody",
-              "isMut": true,
-              "isSigner": false
-            }
-          ]
         },
         {
-          "name": "multisig",
+          "name": "multisigTokenAuthority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "args": [

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -2129,7 +2129,7 @@ export type ExampleNativeTokenTransfers = {
         "kind": "struct",
         "fields": [
           {
-            "name": "revertOnDelay",
+            "name": "revertWhenNotReady",
             "type": "bool"
           }
         ]
@@ -4624,7 +4624,7 @@ export const IDL: ExampleNativeTokenTransfers = {
         "kind": "struct",
         "fields": [
           {
-            "name": "revertOnDelay",
+            "name": "revertWhenNotReady",
             "type": "bool"
           }
         ]

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -267,7 +267,7 @@ export namespace NTT {
         rateLimit: pdas.outboxRateLimitAccount(),
         tokenProgram: args.tokenProgram,
         tokenAuthority: pdas.tokenAuthority(),
-        // NOTE: SPL Multisig token authority is only support for versions >= 3.x.x
+        // NOTE: SPL Multisig token authority is only supported for versions >= 3.x.x
         ...(major >= 3 && {
           multisigTokenAuthority: args.multisigTokenAuthority ?? null,
         }),
@@ -592,7 +592,7 @@ export namespace NTT {
           tokenProgram: config.tokenProgram,
           custody: await custodyAccountAddress(pdas, config),
         },
-        // NOTE: SPL Multisig token authority is only support for versions >= 3.x.x
+        // NOTE: SPL Multisig token authority is only supported for versions >= 3.x.x
         ...(major >= 3 && {
           multisigTokenAuthority,
         }),

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -547,7 +547,7 @@ export namespace NTT {
       payer: PublicKey;
       chain: Chain;
       nttMessage: Ntt.Message;
-      revertOnDelay: boolean;
+      revertWhenNotReady: boolean;
       recipient?: PublicKey;
     },
     pdas?: Pdas
@@ -574,7 +574,10 @@ export namespace NTT {
 
     const transferIx = await program.methods
       .releaseInboundMint({
-        revertOnDelay: args.revertOnDelay,
+        // NOTE: `revertOnDelay` is used for versions < 3.x.x
+        // For versions >= 3.x.x, `revertWhenNotReady` is used instead
+        revertOnDelay: args.revertWhenNotReady,
+        revertWhenNotReady: args.revertWhenNotReady,
       })
       .accounts({
         common: {
@@ -637,7 +640,7 @@ export namespace NTT {
       payer: PublicKey;
       chain: Chain;
       nttMessage: Ntt.Message;
-      revertOnDelay: boolean;
+      revertWhenNotReady: boolean;
       recipient?: PublicKey;
     },
     pdas?: Pdas
@@ -652,7 +655,10 @@ export namespace NTT {
 
     const transferIx = await program.methods
       .releaseInboundUnlock({
-        revertOnDelay: args.revertOnDelay,
+        // NOTE: `revertOnDelay` is used for versions < 3.x.x
+        // For versions >= 3.x.x, `revertWhenNotReady` is used instead
+        revertOnDelay: args.revertWhenNotReady,
+        revertWhenNotReady: args.revertWhenNotReady,
       })
       .accountsStrict({
         common: {

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -244,9 +244,11 @@ export namespace NTT {
       outboundLimit: bigint;
       tokenProgram: PublicKey;
       mode: "burning" | "locking";
+      multisigTokenAuthority?: PublicKey;
     },
     pdas?: Pdas
   ) {
+    const [major, , ,] = parseVersion(program.idl.version);
     const mode: any =
       args.mode === "burning" ? { burning: {} } : { locking: {} };
     const chainId = toChainId(args.chain);
@@ -256,7 +258,7 @@ export namespace NTT {
     const limit = new BN(args.outboundLimit.toString());
     return program.methods
       .initialize({ chainId, limit: limit, mode })
-      .accountsStrict({
+      .accounts({
         payer: args.payer,
         deployer: args.owner,
         programData: programDataAddress(program.programId),
@@ -265,6 +267,10 @@ export namespace NTT {
         rateLimit: pdas.outboxRateLimitAccount(),
         tokenProgram: args.tokenProgram,
         tokenAuthority: pdas.tokenAuthority(),
+        // NOTE: SPL Multisig token authority is only support for versions >= 3.x.x
+        ...(major >= 3 && {
+          multisigTokenAuthority: args.multisigTokenAuthority ?? null,
+        }),
         custody: await NTT.custodyAccountAddress(
           pdas,
           args.mint,
@@ -273,53 +279,6 @@ export namespace NTT {
         bpfLoaderUpgradeableProgram: BPF_LOADER_UPGRADEABLE_PROGRAM_ID,
         associatedTokenProgram: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
         systemProgram: SystemProgram.programId,
-      })
-      .instruction();
-  }
-
-  export async function createInitializeMultisigInstruction(
-    program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
-    args: {
-      payer: PublicKey;
-      owner: PublicKey;
-      chain: Chain;
-      mint: PublicKey;
-      outboundLimit: bigint;
-      tokenProgram: PublicKey;
-      mode: "burning" | "locking";
-      multisig: PublicKey;
-    },
-    pdas?: Pdas
-  ) {
-    const mode: any =
-      args.mode === "burning" ? { burning: {} } : { locking: {} };
-    const chainId = toChainId(args.chain);
-
-    pdas = pdas ?? NTT.pdas(program.programId);
-
-    const limit = new BN(args.outboundLimit.toString());
-    return await program.methods
-      .initializeMultisig({ chainId, limit: limit, mode })
-      .accountsStrict({
-        common: {
-          payer: args.payer,
-          deployer: args.owner,
-          programData: programDataAddress(program.programId),
-          config: pdas.configAccount(),
-          mint: args.mint,
-          rateLimit: pdas.outboxRateLimitAccount(),
-          tokenAuthority: pdas.tokenAuthority(),
-          custody: await NTT.custodyAccountAddress(
-            pdas,
-            args.mint,
-            args.tokenProgram
-          ),
-          tokenProgram: args.tokenProgram,
-          associatedTokenProgram: splToken.ASSOCIATED_TOKEN_PROGRAM_ID,
-          bpfLoaderUpgradeableProgram: BPF_LOADER_UPGRADEABLE_PROGRAM_ID,
-          systemProgram: SystemProgram.programId,
-        },
-        multisig: args.multisig,
       })
       .instruction();
   }
@@ -590,9 +549,12 @@ export namespace NTT {
       nttMessage: Ntt.Message;
       revertOnDelay: boolean;
       recipient?: PublicKey;
+      multisigTokenAuthority?: PublicKey;
     },
     pdas?: Pdas
   ): Promise<TransactionInstruction> {
+    const [major, , ,] = parseVersion(program.idl.version);
+
     pdas = pdas ?? NTT.pdas(program.programId);
 
     const recipientAddress =
@@ -604,7 +566,7 @@ export namespace NTT {
       .releaseInboundMint({
         revertOnDelay: args.revertOnDelay,
       })
-      .accountsStrict({
+      .accounts({
         common: {
           payer: args.payer,
           config: { config: pdas.configAccount() },
@@ -620,90 +582,10 @@ export namespace NTT {
           tokenProgram: config.tokenProgram,
           custody: await custodyAccountAddress(pdas, config),
         },
-      })
-      .instruction();
-
-    const mintInfo = await splToken.getMint(
-      program.provider.connection,
-      config.mint,
-      undefined,
-      config.tokenProgram
-    );
-    const transferHook = splToken.getTransferHook(mintInfo);
-
-    if (transferHook) {
-      const source = await custodyAccountAddress(pdas, config);
-      const mint = config.mint;
-      const destination = getAssociatedTokenAddressSync(
-        mint,
-        recipientAddress,
-        true,
-        config.tokenProgram
-      );
-      const owner = pdas.tokenAuthority();
-      await addExtraAccountMetasForExecute(
-        program.provider.connection,
-        transferIx,
-        transferHook.programId,
-        source,
-        mint,
-        destination,
-        owner,
-        // TODO(csongor): compute the amount that's passed into transfer.
-        // Leaving this 0 is fine unless the transfer hook accounts addresses
-        // depend on the amount (which is unlikely).
-        // If this turns out to be the case, the amount to put here is the
-        // untrimmed amount after removing dust.
-        0
-      );
-    }
-
-    return transferIx;
-  }
-
-  // TODO: document that if recipient is provided, then the instruction can be
-  // created before the inbox item is created (i.e. they can be put in the same tx)
-  export async function createReleaseInboundMintMultisigInstruction(
-    program: Program<NttBindings.NativeTokenTransfer<IdlVersion>>,
-    config: NttBindings.Config<IdlVersion>,
-    args: {
-      payer: PublicKey;
-      chain: Chain;
-      nttMessage: Ntt.Message;
-      revertOnDelay: boolean;
-      multisig: PublicKey;
-      recipient?: PublicKey;
-    },
-    pdas?: Pdas
-  ): Promise<TransactionInstruction> {
-    pdas = pdas ?? NTT.pdas(program.programId);
-
-    const recipientAddress =
-      args.recipient ??
-      (await getInboxItem(program, args.chain, args.nttMessage))
-        .recipientAddress;
-
-    const transferIx = await program.methods
-      .releaseInboundMintMultisig({
-        revertOnDelay: args.revertOnDelay,
-      })
-      .accountsStrict({
-        common: {
-          payer: args.payer,
-          config: { config: pdas.configAccount() },
-          inboxItem: pdas.inboxItemAccount(args.chain, args.nttMessage),
-          recipient: getAssociatedTokenAddressSync(
-            config.mint,
-            recipientAddress,
-            true,
-            config.tokenProgram
-          ),
-          mint: config.mint,
-          tokenAuthority: pdas.tokenAuthority(),
-          tokenProgram: config.tokenProgram,
-          custody: await custodyAccountAddress(pdas, config),
-        },
-        multisig: args.multisig,
+        // NOTE: SPL Multisig token authority is only support for versions >= 3.x.x
+        ...(major >= 3 && {
+          multisigTokenAuthority: args.multisigTokenAuthority ?? null,
+        }),
       })
       .instruction();
 

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -630,7 +630,7 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
       mint: PublicKey;
       mode: Ntt.Mode;
       outboundLimit: bigint;
-      multisig?: PublicKey;
+      multisigTokenAuthority?: PublicKey;
     }
   ) {
     const mintInfo = await this.connection.getAccountInfo(args.mint);
@@ -641,30 +641,18 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
 
     const payer = new SolanaAddress(sender).unwrap();
 
-    const ix = args.multisig
-      ? await NTT.createInitializeMultisigInstruction(
-          this.program,
-          {
-            ...args,
-            payer,
-            owner: payer,
-            chain: this.chain,
-            tokenProgram: mintInfo.owner,
-            multisig: args.multisig,
-          },
-          this.pdas
-        )
-      : await NTT.createInitializeInstruction(
-          this.program,
-          {
-            ...args,
-            payer,
-            owner: payer,
-            chain: this.chain,
-            tokenProgram: mintInfo.owner,
-          },
-          this.pdas
-        );
+    const ix = await NTT.createInitializeInstruction(
+      this.program,
+      {
+        ...args,
+        payer,
+        owner: payer,
+        chain: this.chain,
+        tokenProgram: mintInfo.owner,
+        multisigTokenAuthority: args.multisigTokenAuthority,
+      },
+      this.pdas
+    );
 
     const tx = new Transaction();
     tx.feePayer = payer;
@@ -969,7 +957,7 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
   async *redeem(
     attestations: Ntt.Attestation[],
     payer: AccountAddress<C>,
-    multisig?: PublicKey
+    multisigTokenAuthority?: PublicKey
   ) {
     const config = await this.getConfig();
     if (config.paused) throw new Error("Contract is paused");
@@ -1032,20 +1020,10 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
             ? NTT.createReleaseInboundUnlockInstruction(this.program, config, {
                 ...releaseArgs,
               })
-            : multisig
-            ? NTT.createReleaseInboundMintMultisigInstruction(
-                this.program,
-                config,
-                {
-                  ...releaseArgs,
-                  multisig,
-                }
-              )
-            : NTT.createReleaseInboundMintInstruction(
-                this.program,
-                config,
-                releaseArgs
-              );
+            : NTT.createReleaseInboundMintInstruction(this.program, config, {
+                ...releaseArgs,
+                multisigTokenAuthority,
+              });
 
         const tx = new Transaction();
         tx.feePayer = senderAddress;

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -954,11 +954,7 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
     }
   }
 
-  async *redeem(
-    attestations: Ntt.Attestation[],
-    payer: AccountAddress<C>,
-    multisigTokenAuthority?: PublicKey
-  ) {
+  async *redeem(attestations: Ntt.Attestation[], payer: AccountAddress<C>) {
     const config = await this.getConfig();
     if (config.paused) throw new Error("Contract is paused");
 
@@ -1022,7 +1018,6 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
               })
             : NTT.createReleaseInboundMintInstruction(this.program, config, {
                 ...releaseArgs,
-                multisigTokenAuthority,
               });
 
         const tx = new Transaction();

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -1009,7 +1009,8 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
             nttMessage.payload.recipientAddress.toUint8Array()
           ),
           chain: emitterChain,
-          revertOnDelay: false,
+          // NOTE: this acts as `revertOnDelay` for versions < 3.x.x
+          revertWhenNotReady: false,
         };
         let releaseIx =
           config.mode.locking != null
@@ -1181,7 +1182,8 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
         transceiverMessage.payload.recipientAddress.toUint8Array()
       ),
       chain: fromChain,
-      revertOnDelay: false,
+      // NOTE: this acts as `revertOnDelay` for versions < 3.x.x
+      revertWhenNotReady: false,
     };
 
     tx.add(


### PR DESCRIPTION
This PR adds:
* Remove `initialize_multisig` and `release_inbound_mint_multisig` ix
* Add `Option<'info, SplMultisig<'info>>` account to `Initialize` and `ReleaseInboundMint` struct
* Update cargo and TS tests
* Derive multisig token authority from the token mint authority
* Update IDL