### PR TITLE
AVAX/Blast support

### DIFF
--- a/solana/ts/scripts/config/mainnet/quoter.json
+++ b/solana/ts/scripts/config/mainnet/quoter.json
@@ -290,7 +290,15 @@
       "gasGost": 500000,
       "wormholeTransceiverIndex": 0,
       "isSupported": true
-    }
+    },
+    {
+      "name": "AVAX",
+      "programId": "ntTW3X39Vo1G7YdnAt62TYexBoFMfBzcJozXvmdNKtv",
+      "tokenAddress": "yNBMYD9LMrmGpWbAFbJv5UkkqSvKEupvSGSZxSz7wN5",
+      "gasGost": 500000,
+      "wormholeTransceiverIndex": 0,
+      "isSupported": true
+    },
   ],
   "peerQuotes": {
     "Ethereum": {
@@ -333,6 +341,12 @@
       "maxGasDropoffEth": "0",
       "basePriceUsd": "0",
       "nativePriceUsd": "0.41",
+      "gasPriceGwei": "0"
+    },
+    "Blast": {
+      "maxGasDropoffEth": "0",
+      "basePriceUsd": "0",
+      "nativePriceUsd": "1975.00",
       "gasPriceGwei": "0"
     }
   }

--- a/solana/ts/scripts/registerManagers.ts
+++ b/solana/ts/scripts/registerManagers.ts
@@ -14,6 +14,8 @@ async function run() {
   const quoter = new NttQuoter(connection, programs.quoterProgramId);
 
   for (const managerConfig of config.managerRegistrations) {
+    await sleep(1000); // HACK avoid 429 rate limit error
+
     const nttKey = new PublicKey(managerConfig.programId);
     const registration = await quoter.tryGetRegisteredNtt(nttKey);
     console.log(`Registration for manager ${managerConfig.programId} (${managerConfig.name}):`, registration);
@@ -64,7 +66,14 @@ async function run() {
         `Failed to register or de-register manager ${managerConfig.programId}: ${error}`
       );
     }
+  
+  
   }
 }
 
 run();
+
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Includes sleep() for registerManager to avoid 429 during registrations.