### PR TITLE
solana: Make `initialize_lut` instruction permissioned by `owner`

### DIFF
--- a/solana/programs/example-native-token-transfers/src/instructions/admin/mod.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin/mod.rs
@@ -149,7 +149,6 @@ pub struct DeregisterTransceiver<'info> {
     )]
     pub config: Account<'info, Config>,
 
-    #[account(mut)]
     pub owner: Signer<'info>,
 
     #[account(executable)]

--- a/solana/programs/example-native-token-transfers/src/instructions/luts.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/luts.rs
@@ -5,9 +5,12 @@
 //! client could just manage its own ad-hoc lookup table.
 //! Nevertheless, we provide this instruction to make it easier for the client
 //! to query the lookup table from a deterministic address, and for integrators
-//! to be able to fetch the accounts from the LUT in a standardised way. However,
-//! since an attacker could permissionlessly backrun the lookup table, we make it
-//! permissioned.
+//! to be able to fetch the accounts from the LUT in a standardised way.
+//!
+//! Currently the `fee_collector` and `sequence` in the [`Entries`] struct are
+//! unconstrainted and are only verified by the core bridge. Thus it is possible
+//! for an attacker to fill the LUT with garbage values for those accounts.
+//! To avoid this, we make this call permissioned.
 //!
 //! This way, the client sdk can abstract away the lookup table logic in a
 //! maintanable way.

--- a/solana/programs/example-native-token-transfers/src/instructions/luts.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/luts.rs
@@ -5,7 +5,9 @@
 //! client could just manage its own ad-hoc lookup table.
 //! Nevertheless, we provide this instruction to make it easier for the client
 //! to query the lookup table from a deterministic address, and for integrators
-//! to be able to fetch the accounts from the LUT in a standardised way.
+//! to be able to fetch the accounts from the LUT in a standardised way. However,
+//! since an attacker could permissionlessly backrun the lookup table, we make it
+//! permissioned
 //!
 //! This way, the client sdk can abstract away the lookup table logic in a
 //! maintanable way.
@@ -19,8 +21,6 @@
 //! sorted), and in the worst case would require ~16k checks. So we keep things
 //! simple, and just create a new LUT each time. This operation won't be called
 //! often, so the extra allocation is justifiable.
-//!
-//! Because of all the above, this instruction can be called permissionlessly.
 
 use anchor_lang::prelude::*;
 use solana_address_lookup_table_program;
@@ -40,6 +40,8 @@ pub struct LUT {
 pub struct InitializeLUT<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
+
+    pub owner: Signer<'info>,
 
     #[account(
         seeds = [b"lut_authority"],
@@ -73,6 +75,7 @@ pub struct InitializeLUT<'info> {
     pub system_program: Program<'info, System>,
 
     /// These are the entries that will populate the LUT.
+    #[account(constraint = entries.config.owner == owner.key())]
     pub entries: Entries<'info>,
 }
 

--- a/solana/programs/example-native-token-transfers/src/instructions/luts.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/luts.rs
@@ -7,7 +7,7 @@
 //! to query the lookup table from a deterministic address, and for integrators
 //! to be able to fetch the accounts from the LUT in a standardised way. However,
 //! since an attacker could permissionlessly backrun the lookup table, we make it
-//! permissioned
+//! permissioned.
 //!
 //! This way, the client sdk can abstract away the lookup table logic in a
 //! maintanable way.

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -105,6 +105,11 @@
           "isSigner": true
         },
         {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": false,
           "isSigner": false
@@ -1203,7 +1208,7 @@
         },
         {
           "name": "owner",
-          "isMut": true,
+          "isMut": false,
           "isSigner": true
         },
         {

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -105,6 +105,11 @@ export type ExampleNativeTokenTransfers = {
           "isSigner": true
         },
         {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": false,
           "isSigner": false
@@ -1203,7 +1208,7 @@ export type ExampleNativeTokenTransfers = {
         },
         {
           "name": "owner",
-          "isMut": true,
+          "isMut": false,
           "isSigner": true
         },
         {
@@ -2600,6 +2605,11 @@ export const IDL: ExampleNativeTokenTransfers = {
           "isSigner": true
         },
         {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
           "name": "authority",
           "isMut": false,
           "isSigner": false
@@ -3698,7 +3708,7 @@ export const IDL: ExampleNativeTokenTransfers = {
         },
         {
           "name": "owner",
-          "isMut": true,
+          "isMut": false,
           "isSigner": true
         },
         {

--- a/solana/ts/lib/ntt.ts
+++ b/solana/ts/lib/ntt.ts
@@ -291,6 +291,7 @@ export namespace NTT {
     whTransceiver: PublicKey,
     args: {
       payer: PublicKey;
+      owner: PublicKey;
       wormholeId: PublicKey;
     },
     pdas?: Pdas
@@ -371,6 +372,7 @@ export namespace NTT {
       .initializeLut(new BN(slot))
       .accountsStrict({
         payer: args.payer,
+        owner: args.owner,
         authority: pdas.lutAuthority(),
         lutAddress,
         lut: pdas.lutAccount(),

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -662,10 +662,10 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
       "Ntt.Initialize"
     );
 
-    yield* this.initializeOrUpdateLUT({ payer });
+    yield* this.initializeOrUpdateLUT({ payer, owner: payer });
   }
 
-  async *initializeOrUpdateLUT(args: { payer: PublicKey }) {
+  async *initializeOrUpdateLUT(args: { payer: PublicKey; owner: PublicKey }) {
     const config = await this.getConfig();
 
     const whTransceiver = await this.getWormholeTransceiver();
@@ -680,6 +680,7 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
       whTransceiverProgramId,
       {
         payer: args.payer,
+        owner: args.owner,
         wormholeId: new PublicKey(this.core.address),
       }
     );


### PR DESCRIPTION
Since `initialize_lut` instruction is permissionless, an attacker could theoretically backrun the lookup table with garbage values for `sequence` and `fee_collector` accounts as they are unconstrained in this call and are only verified by the core bridge. This could cause transactions that depend on the LUT being initialized correctly to fail due to size constraints. This PR makes `initialize_lut` permissioned using the `owner`.