### PR TITLE
Tests and fixes when core bridge messageFee is > 0

### DIFF
--- a/cli/test/sepolia-bsc.sh
+++ b/cli/test/sepolia-bsc.sh
@@ -8,17 +8,51 @@ set -euox pipefail
 
 BSC_PORT=8545
 SEPOLIA_PORT=8546
+BSC_RPC_URL=https://bsc-testnet-rpc.publicnode.com
+SEPOLIA_RPC_URL=wss://ethereum-sepolia-rpc.publicnode.com
+SEPOLIA_FORK_RPC_URL=http://127.0.0.1:$SEPOLIA_PORT
+BSC_FORK_RPC_URL=http://127.0.0.1:$BSC_PORT
+SEPOLIA_CORE_BRIDGE=0x4a8bc80Ed5a4067f1CCf107057b8270E0cC11A78
+BSC_CORE_BRIDGE=0x68605AD7b15c732a30b1BbC62BE8F2A509D74b4D
 
-anvil --silent --rpc-url https://bsc-testnet-rpc.publicnode.com -p "$BSC_PORT" &
+anvil --silent --rpc-url $BSC_RPC_URL -p "$BSC_PORT" &
 pid1=$!
-anvil --silent --rpc-url wss://ethereum-sepolia-rpc.publicnode.com -p "$SEPOLIA_PORT" &
+anvil --silent --rpc-url $SEPOLIA_RPC_URL -p "$SEPOLIA_PORT" &
 pid2=$!
-
 # check both processes are running
 if ! kill -0 $pid1 || ! kill -0 $pid2; then
   echo "Failed to start the servers"
   exit 1
 fi
+
+# wait for RPC endpoints to be ready
+wait_for_rpc() {
+  local url=$1
+  local max_attempts=30
+  local attempt=1
+  
+  echo "Waiting for RPC endpoint $url to be ready..."
+  while [ $attempt -le $max_attempts ]; do
+    if curl -s -X POST "$url" \
+      -H "Content-Type: application/json" \
+      --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' > /dev/null 2>&1; then
+      echo "RPC endpoint $url is ready"
+      return 0
+    fi
+    echo "Attempt $attempt/$max_attempts: RPC not ready yet, waiting..."
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+  echo "RPC endpoint $url failed to become ready after $max_attempts attempts"
+  return 1
+}
+
+wait_for_rpc "$SEPOLIA_FORK_RPC_URL" || exit 1
+wait_for_rpc "$BSC_FORK_RPC_URL" || exit 1
+
+# setting core bridge fee to 0.001 (7 = `messageFee` storage slot)
+curl "$SEPOLIA_FORK_RPC_URL" -H "Content-Type: application/json" --data "{\"jsonrpc\":\"2.0\",\"method\":\"anvil_setStorageAt\",\"params\":[\"$SEPOLIA_CORE_BRIDGE\", 7 ,\"0x00000000000000000000000000000000000000000000000000038D7EA4C68000\"],\"id\":1}"
+curl "$BSC_FORK_RPC_URL" -H "Content-Type: application/json" --data "{\"jsonrpc\":\"2.0\",\"method\":\"anvil_setStorageAt\",\"params\":[\"$BSC_CORE_BRIDGE\", 7 ,\"0x00000000000000000000000000000000000000000000000000038D7EA4C68000\"],\"id\":1}"
 
 # create tmp directory
 dir=$(mktemp -d)
@@ -44,15 +78,15 @@ cat <<EOF > overrides.json
 {
   "chains": {
     "Bsc": {
-      "rpc": "http://127.0.0.1:$BSC_PORT"
+      "rpc": "$BSC_FORK_RPC_URL"
     },
     "Sepolia": {
-      "rpc": "http://127.0.0.1:$SEPOLIA_PORT"
+      "rpc": "$SEPOLIA_FORK_RPC_URL"
     }
   }
 }
 EOF
-
+-
 ntt add-chain Bsc --token 0x0B15635FCF5316EdFD2a9A0b0dC3700aeA4D09E6 --mode locking --skip-verify --latest
 ntt add-chain Sepolia --token 0xB82381A3fBD3FaFA77B3a7bE693342618240067b --skip-verify --ver 1.0.0
 

--- a/cli/test/sepolia-bsc.sh
+++ b/cli/test/sepolia-bsc.sh
@@ -86,7 +86,7 @@ cat <<EOF > overrides.json
   }
 }
 EOF
--
+
 ntt add-chain Bsc --token 0x0B15635FCF5316EdFD2a9A0b0dC3700aeA4D09E6 --mode locking --skip-verify --latest
 ntt add-chain Sepolia --token 0xB82381A3fBD3FaFA77B3a7bE693342618240067b --skip-verify --ver 1.0.0
 

--- a/evm/script/ConfigureWormholeNtt.s.sol
+++ b/evm/script/ConfigureWormholeNtt.s.sol
@@ -10,8 +10,8 @@ import "../src/interfaces/IOwnableUpgradeable.sol";
 
 import {ParseNttConfig} from "./helpers/ParseNttConfig.sol";
 import {WormholeTransceiver} from "../src/Transceiver/WormholeTransceiver/WormholeTransceiver.sol";
-import {WormholeTransceiverState} from "../src/Transceiver/WormholeTransceiver/WormholeTransceiverState.sol";
-
+import {WormholeTransceiverState} from
+    "../src/Transceiver/WormholeTransceiver/WormholeTransceiverState.sol";
 
 contract ConfigureWormholeNtt is ParseNttConfig {
     using stdJson for string;
@@ -44,9 +44,10 @@ contract ConfigureWormholeNtt is ParseNttConfig {
                     wormholeTransceiver.setIsSpecialRelayingEnabled(targetConfig.chainId, true);
                     console2.log("Special relaying enabled for chain", targetConfig.chainId);
                 }
-                uint256 messageFee = WormholeTransceiverState(address(wormholeTransceiver)).wormhole().messageFee();
+                uint256 messageFee =
+                    WormholeTransceiverState(address(wormholeTransceiver)).wormhole().messageFee();
                 // Set peer.
-                wormholeTransceiver.setWormholePeer{ value: messageFee }(
+                wormholeTransceiver.setWormholePeer{value: messageFee}(
                     targetConfig.chainId, targetConfig.wormholeTransceiver
                 );
                 console2.log("Wormhole peer set for chain", targetConfig.chainId);

--- a/evm/script/ConfigureWormholeNtt.s.sol
+++ b/evm/script/ConfigureWormholeNtt.s.sol
@@ -10,6 +10,8 @@ import "../src/interfaces/IOwnableUpgradeable.sol";
 
 import {ParseNttConfig} from "./helpers/ParseNttConfig.sol";
 import {WormholeTransceiver} from "../src/Transceiver/WormholeTransceiver/WormholeTransceiver.sol";
+import {WormholeTransceiverState} from "../src/Transceiver/WormholeTransceiver/WormholeTransceiverState.sol";
+
 
 contract ConfigureWormholeNtt is ParseNttConfig {
     using stdJson for string;
@@ -42,9 +44,9 @@ contract ConfigureWormholeNtt is ParseNttConfig {
                     wormholeTransceiver.setIsSpecialRelayingEnabled(targetConfig.chainId, true);
                     console2.log("Special relaying enabled for chain", targetConfig.chainId);
                 }
-
+                uint256 messageFee = WormholeTransceiverState(address(wormholeTransceiver)).wormhole().messageFee();
                 // Set peer.
-                wormholeTransceiver.setWormholePeer(
+                wormholeTransceiver.setWormholePeer{ value: messageFee }(
                     targetConfig.chainId, targetConfig.wormholeTransceiver
                 );
                 console2.log("Wormhole peer set for chain", targetConfig.chainId);

--- a/evm/script/DeployWormholeNtt.s.sol
+++ b/evm/script/DeployWormholeNtt.s.sol
@@ -80,7 +80,7 @@ contract DeployWormholeNtt is Script, DeployWormholeNttBase {
 
         // Deploy NttManager.
         address manager = deployNttManager(params);
-        
+
         // Deploy Wormhole Transceiver.
         address transceiver = deployWormholeTransceiver(params, manager);
 

--- a/evm/script/DeployWormholeNtt.s.sol
+++ b/evm/script/DeployWormholeNtt.s.sol
@@ -80,7 +80,7 @@ contract DeployWormholeNtt is Script, DeployWormholeNttBase {
 
         // Deploy NttManager.
         address manager = deployNttManager(params);
-
+        
         // Deploy Wormhole Transceiver.
         address transceiver = deployWormholeTransceiver(params, manager);
 

--- a/evm/script/helpers/DeployWormholeNttBase.sol
+++ b/evm/script/helpers/DeployWormholeNttBase.sol
@@ -78,7 +78,7 @@ contract DeployWormholeNttBase is ParseNttConfig {
         IWormhole wh = IWormhole(params.wormholeCoreBridge);
         uint256 messageFee = wh.messageFee();
         // wh transceiver sends a WH_TRANSCEIVER_INIT_PREFIX message
-        transceiverProxy.initialize{ value: messageFee }();
+        transceiverProxy.initialize{value: messageFee}();
 
         console2.log("WormholeTransceiver:", address(transceiverProxy));
 

--- a/evm/script/helpers/DeployWormholeNttBase.sol
+++ b/evm/script/helpers/DeployWormholeNttBase.sol
@@ -12,6 +12,10 @@ import {WormholeTransceiver} from
     "../../src/Transceiver/WormholeTransceiver/WormholeTransceiver.sol";
 import {ERC1967Proxy} from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
+interface IWormhole {
+    function messageFee() external view returns (uint256);
+}
+
 contract DeployWormholeNttBase is ParseNttConfig {
     struct DeploymentParams {
         address token;
@@ -71,7 +75,10 @@ contract DeployWormholeNttBase is ParseNttConfig {
         WormholeTransceiver transceiverProxy =
             WormholeTransceiver(address(new ERC1967Proxy(address(implementation), "")));
 
-        transceiverProxy.initialize();
+        IWormhole wh = IWormhole(params.wormholeCoreBridge);
+        uint256 messageFee = wh.messageFee();
+        // wh transceiver sends a WH_TRANSCEIVER_INIT_PREFIX message
+        transceiverProxy.initialize{ value: messageFee }();
 
         console2.log("WormholeTransceiver:", address(transceiverProxy));
 

--- a/sdk/__tests__/index.test.ts
+++ b/sdk/__tests__/index.test.ts
@@ -2,7 +2,8 @@ import { web3 } from "@coral-xyz/anchor";
 import { chainToPlatform } from "@wormhole-foundation/sdk-connect";
 
 import { registerRelayers } from "./accountant.js";
-import { Ctx, testHub } from "./utils.js";
+import { Ctx, setMessageFee, testHub } from "./utils.js";
+import { ethers } from "ethers";
 
 // Note: Currently, in order for this to run, the evm bindings with extra contracts must be build
 // To do that, at the root, run `npm run generate:test`
@@ -62,6 +63,11 @@ const makeGetNativeSigner =
 describe("Hub and Spoke Tests", function () {
   beforeAll(async () => {
     await registerRelayers(ACCT_MNEMONIC);
+    await setMessageFee(["Ethereum", "Bsc"], ethers.parseEther("0.001"));
+  });
+
+  afterAll(async () => {
+    await setMessageFee(["Ethereum", "Bsc"], 0n);
   });
 
   test("Test Solana and Ethereum Hubs", async () => {


### PR DESCRIPTION
* Set a `messageFee` > 0 for NTT SDK e2e tests  (Tilt)
* Set a `messageFee` > 0 for NTT cli tests
* Fixed a couple of issues regarding `wormholeTransceiver.initialize` and `wormholeTransceiver.setWormholePeer`, both functions are sending a message via core bridge and in some cases `messageFee` was not taken into account