### PR TITLE
[wip] NttOwner support

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,3 +1,7 @@
+
+deployment.json
+id.json
+
 # Based on https://raw.githubusercontent.com/github/gitignore/main/Node.gitignore
 
 # Logs
@@ -173,3 +177,4 @@ dist
 
 # Finder (MacOS) folder config
 .DS_Store
+

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,8 +2,9 @@
 import "./side-effects"; // doesn't quite work for silencing the bigint error message. why?
 import evm from "@wormhole-foundation/sdk/platforms/evm";
 import solana from "@wormhole-foundation/sdk/platforms/solana";
-import { encoding } from '@wormhole-foundation/sdk-connect';
+import { encoding, type RpcConnection, type UnsignedTransaction, type WormholeConfigOverrides } from '@wormhole-foundation/sdk-connect';
 import { execSync } from "child_process";
+import * as myEvmSigner from "./evmsigner.js";
 
 import evmDeployFile from "../../evm/script/DeployWormholeNtt.s.sol" with { type: "file" };
 import evmDeployFileHelper from "../../evm/script/helpers/DeployWormholeNttBase.sol" with { type: "file" };
@@ -16,7 +17,7 @@ import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import * as spl from "@solana/spl-token";
 import fs from "fs";
 import readline from "readline";
-import { ChainContext, UniversalAddress, Wormhole, assertChain, canonicalAddress, chainToPlatform, chains, isNetwork, networks, platforms, signSendWait, toUniversal, type AccountAddress, type Chain, type ChainAddress, type ConfigOverrides, type Network, type Platform } from "@wormhole-foundation/sdk";
+import { ChainContext, UniversalAddress, Wormhole, assertChain, canonicalAddress, chainToPlatform, chains, isNetwork, networks, platforms, signSendWait, toUniversal, type AccountAddress, type Chain, type ChainAddress, type Network, type Platform } from "@wormhole-foundation/sdk";
 import "@wormhole-foundation/sdk-evm-ntt";
 import "@wormhole-foundation/sdk-solana-ntt";
 import "@wormhole-foundation/sdk-definitions-ntt";
@@ -28,10 +29,10 @@ import { colorizeDiff, diffObjects } from "./diff";
 import { forgeSignerArgs, getSigner, type SignerType } from "./getSigner";
 import { NTT, SolanaNtt } from "@wormhole-foundation/sdk-solana-ntt";
 import type { EvmNtt, EvmNttWormholeTranceiver } from "@wormhole-foundation/sdk-evm-ntt";
-import type { EvmChains } from "@wormhole-foundation/sdk-evm";
+import type { EvmChains, EvmNativeSigner, EvmUnsignedTransaction } from "@wormhole-foundation/sdk-evm";
 import { getAvailableVersions, getGitTagName } from "./tag";
 import * as configuration from "./configuration";
-import { ethers } from "ethers";
+import { AbiCoder, ethers, Interface } from "ethers";
 
 // TODO: contract upgrades on solana
 // TODO: set special relaying?
@@ -39,7 +40,7 @@ import { ethers } from "ethers";
 
 // TODO: check if manager can mint the token in burning mode (on solana it's
 // simple. on evm we need to simulate with prank)
-const overrides: ConfigOverrides<Network> = (function () {
+const overrides: WormholeConfigOverrides<Network> = (function () {
     // read overrides.json file if exists
     if (fs.existsSync("overrides.json")) {
         console.error(chalk.yellow("Using overrides.json"));
@@ -163,6 +164,11 @@ const options = {
     payer: {
         describe: "Path to the payer json file (Solana)",
         type: "string",
+    },
+    skipChain: {
+        describe: "Skip chains",
+        type: "array",
+        choices: chains,
     },
 } as const;
 
@@ -646,6 +652,7 @@ yargs(hideBin(process.argv))
             .option("verbose", options.verbose)
             .option("skip-verify", options.skipVerify)
             .option("payer", options.payer)
+            .option("skip-chain", options.skipChain)
             .example("$0 push", "Push local configuration changes to the blockchain")
             .example("$0 push --signer-type ledger", "Push changes using a Ledger hardware wallet for signing")
             .example("$0 push --skip-verify", "Push changes without verifying contracts on EVM chains")
@@ -657,7 +664,7 @@ yargs(hideBin(process.argv))
             const deps: Partial<{ [C in Chain]: Deployment<Chain> }> = await pullDeployments(deployments, network, verbose);
             const signerType = argv["signer-type"] as SignerType;
             const payerPath = argv["payer"];
-
+            const skipChains = argv["skip-chain"] as string[];
             const missing = await missingConfigs(deps, verbose);
 
             if (checkConfigErrors(deps)) {
@@ -666,29 +673,100 @@ yargs(hideBin(process.argv))
             }
 
             for (const [chain, missingConfig] of Object.entries(missing)) {
+                if(skipChains.includes(chain)) {
+                    console.log(`skipping registration for chain ${chain}`)
+                    continue
+                }
                 assertChain(chain);
                 const ntt = deps[chain]!.ntt;
                 const ctx = deps[chain]!.ctx;
                 const signer = await getSigner(ctx, signerType, undefined, payerPath);
-                for (const manager of missingConfig.managerPeers) {
-                    const tx = ntt.setPeer(manager.address, manager.tokenDecimals, manager.inboundLimit, signer.address.address)
-                    await signSendWait(ctx, tx, signer.signer)
+                let nttOwner: AccountAddress<typeof chain> | undefined
+                if (chainToPlatform(chain) === "Evm") {
+                    const rpc = ctx.config.rpc;
+                    const provider = new ethers.JsonRpcProvider(rpc);
+                    // get the owner of the ntt manager
+                    const contractOwner = await ntt.getOwner();
+                    // check if the owner has data to see if it is a smart contract
+                    if(!signer.address.address.equals(contractOwner.toUniversalAddress())) {
+                        const contractCode = await provider.getCode(contractOwner.address.toString())
+                        if(contractCode.length <= 2) {
+                            console.error(`cannot update ${chain} because the configured private key does not correspond to owner ${contractOwner.address}`)
+                            continue
+                        } else {
+                            // assume if that there's code, that it's the same interface as the bootnode NttOwner
+                            nttOwner = contractOwner
+                        }
+                    }
                 }
-                for (const transceiver of missingConfig.transceiverPeers) {
-                    const tx = ntt.setTransceiverPeer(0, transceiver, signer.address.address)
-                    await signSendWait(ctx, tx, signer.signer)
-                }
-                for (const evmChain of missingConfig.evmChains) {
-                    const tx = (await ntt.getTransceiver(0) as EvmNttWormholeTranceiver<Network, EvmChains>).setIsEvmChain(evmChain, true)
-                    await signSendWait(ctx, tx, signer.signer)
-                }
-                for (const relayingTarget of missingConfig.standardRelaying) {
-                    const tx = (await ntt.getTransceiver(0) as EvmNttWormholeTranceiver<Network, EvmChains>).setIsWormholeRelayingEnabled(relayingTarget, true)
-                    await signSendWait(ctx, tx, signer.signer)
-                }
-                for (const relayingTarget of missingConfig.specialRelaying) {
-                    const tx = (await ntt.getTransceiver(0) as EvmNttWormholeTranceiver<Network, EvmChains>).setIsSpecialRelayingEnabled(relayingTarget, true)
-                    await signSendWait(ctx, tx, signer.signer)
+                if(nttOwner !== undefined && chainToPlatform(chain) === "Evm") {
+                    const evmSigner = signer.signer as any as EvmNativeSigner<typeof network>
+                    const evmNtt = ntt as EvmNtt<typeof network, EvmChains>;
+                    const executorInterface = new Interface(["function execute(address target, bytes calldata data)"] as const)
+                    const signSendWaitEvm = async (txs: AsyncGenerator<EvmUnsignedTransaction<typeof network, EvmChains>>) => {
+                        for await (const tx of txs) {
+                            if(tx.transaction.to === undefined) {
+                                console.log(`skipping evm txn with no to address`)
+                                continue
+                            }
+                            // reencode the call data to call the execute function
+                            const newCallData = executorInterface.encodeFunctionData("execute", [tx.transaction.to, tx.transaction.data])
+                            tx.transaction.data = newCallData
+                            // set the new target to the ntt owner
+                            tx.transaction.to = nttOwner.toString()
+
+                            try {
+                            const signedTx = await evmSigner.sign([tx])
+                            await ctx.sendWait(signedTx)
+                            }catch (e) {
+                                console.warn(`failed to execute tx on ${chain}`)
+                                throw e
+                            }
+                        }
+                    }
+                    for (const manager of missingConfig.managerPeers) {
+                        // NOTE: type hack here
+                        const tx = evmNtt.setPeer(manager.address as any, manager.tokenDecimals, manager.inboundLimit)
+                        await signSendWaitEvm(tx)
+                    }
+                    for (const transceiver of missingConfig.transceiverPeers) {
+                        // NOTE: type hack here
+                        const tx = evmNtt.setTransceiverPeer(0, transceiver as any)
+                        await signSendWaitEvm(tx)
+                    }
+                    for (const evmChain of missingConfig.evmChains) {
+                        const tx = (await evmNtt.getTransceiver(0) as EvmNttWormholeTranceiver<Network, EvmChains>).setIsEvmChain(evmChain, true)
+                        await signSendWaitEvm(tx)
+                    }
+                    for (const relayingTarget of missingConfig.standardRelaying) {
+                        const tx = (await ntt.getTransceiver(0) as EvmNttWormholeTranceiver<Network, EvmChains>).setIsWormholeRelayingEnabled(relayingTarget, true)
+                        await signSendWaitEvm(tx)
+                    }
+                    for (const relayingTarget of missingConfig.specialRelaying) {
+                        const tx = (await ntt.getTransceiver(0) as EvmNttWormholeTranceiver<Network, EvmChains>).setIsSpecialRelayingEnabled(relayingTarget, true)
+                        await signSendWaitEvm(tx)
+                    }
+                } else {
+                    for (const manager of missingConfig.managerPeers) {
+                        const tx = ntt.setPeer(manager.address, manager.tokenDecimals, manager.inboundLimit, signer.address.address)
+                        await signSendWait(ctx, tx, signer.signer)
+                    }
+                    for (const transceiver of missingConfig.transceiverPeers) {
+                        const tx = ntt.setTransceiverPeer(0, transceiver, signer.address.address)
+                        await signSendWait(ctx, tx, signer.signer)
+                    }
+                    for (const evmChain of missingConfig.evmChains) {
+                        const tx = (await ntt.getTransceiver(0) as EvmNttWormholeTranceiver<Network, EvmChains>).setIsEvmChain(evmChain, true)
+                        await signSendWait(ctx, tx, signer.signer)
+                    }
+                    for (const relayingTarget of missingConfig.standardRelaying) {
+                        const tx = (await ntt.getTransceiver(0) as EvmNttWormholeTranceiver<Network, EvmChains>).setIsWormholeRelayingEnabled(relayingTarget, true)
+                        await signSendWait(ctx, tx, signer.signer)
+                    }
+                    for (const relayingTarget of missingConfig.specialRelaying) {
+                        const tx = (await ntt.getTransceiver(0) as EvmNttWormholeTranceiver<Network, EvmChains>).setIsSpecialRelayingEnabled(relayingTarget, true)
+                        await signSendWait(ctx, tx, signer.signer)
+                    }
                 }
                 if (missingConfig.solanaWormholeTransceiver) {
                     if (chainToPlatform(chain) !== "Solana") {
@@ -725,6 +803,10 @@ yargs(hideBin(process.argv))
             const depsAfterRegistrations: Partial<{ [C in Chain]: Deployment<Chain> }> = await pullDeployments(deployments, network, verbose);
 
             for (const [chain, deployment] of Object.entries(depsAfterRegistrations)) {
+                if(skipChains.includes(chain)) {
+                    console.log(`skipping deployment for chain ${chain}`)
+                    continue
+                }
                 assertChain(chain);
                 await pushDeployment(deployment as any, signerType, !argv["skip-verify"], argv["yes"], payerPath);
             }
@@ -1035,9 +1117,9 @@ ${ntt.managerAddress} \
 ${signerArgs} \
 --broadcast \
 ${verifyArgs} | tee last-run.stdout`, {
-            cwd: `${pwd}/evm`,
-            stdio: "inherit"
-        });
+                cwd: `${pwd}/evm`,
+                stdio: "inherit"
+            });
     });
 
 }
@@ -1162,10 +1244,10 @@ forge script --via-ir script/DeployWormholeNtt.s.sol \
 ${simulateArg} \
 --sig "${sig}" ${wormhole} ${token} ${relayer} ${specialRelayer} ${decimals} ${modeUint} \
 --broadcast ${verifyArgs.join(' ')} ${signerArgs} 2>&1 | tee last-run.stdout`, {
-                    cwd: `${pwd}/evm`,
-                    encoding: 'utf8',
-                    stdio: 'inherit'
-                });
+                        cwd: `${pwd}/evm`,
+                        encoding: 'utf8',
+                        stdio: 'inherit'
+                    });
             } catch (error) {
                 console.error("Failed to deploy manager");
                 // NOTE: we don't exit here. instead, we check if the manager was
@@ -1357,8 +1439,8 @@ async function deploySolana<N extends Network, C extends SolanaChains>(
                     "-p", "example_native_token_transfers",
                     "--", "--no-default-features", "--features", cargoNetworkFeature(ch.network)
                 ], {
-                cwd: `${pwd}/solana`
-            });
+                    cwd: `${pwd}/solana`
+                });
 
             // const _out = await new Response(proc.stdout).text();
 
@@ -1699,7 +1781,7 @@ async function pullDeployments(deployments: Config, network: Network, verbose: b
 async function pullChainConfig<N extends Network, C extends Chain>(
     network: N,
     manager: ChainAddress<C>,
-    overrides?: ConfigOverrides<N>
+    overrides?: WormholeConfigOverrides<N>
 ): Promise<[ChainConfig, ChainContext<typeof network, C>, Ntt<typeof network, C>, number]> {
     const wh = new Wormhole(network, [solana.Platform, evm.Platform], overrides);
     const ch = wh.getChain(manager.chain);
@@ -1707,7 +1789,7 @@ async function pullChainConfig<N extends Network, C extends Chain>(
     const nativeManagerAddress = canonicalAddress(manager);
 
     const { ntt, addresses }: { ntt: Ntt<N, C>; addresses: Partial<Ntt.Contracts>; } =
-        await nttFromManager<N, C>(ch, nativeManagerAddress);
+    await nttFromManager<N, C>(ch, nativeManagerAddress);
 
     const mode = await ntt.getMode();
     const outboundLimit = await ntt.getOutboundLimit();

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,11 +92,8 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "^1.14.2",
-        "@wormhole-foundation/sdk-definitions": "^1.14.2",
         "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
-        "@wormhole-foundation/sdk-evm": "^1.14.2",
-        "@wormhole-foundation/sdk-evm-core": "^1.14.2"
+        "ethers": "^6.5.1"
       },
       "devDependencies": {
         "@typechain/ethers-v6": "^0.5.1",
@@ -12992,7 +12989,6 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "^1.14.2",
         "@wormhole-foundation/sdk-definitions-ntt": "0.5.0",
         "@wormhole-foundation/sdk-evm-ntt": "0.5.0",
         "@wormhole-foundation/sdk-solana-ntt": "0.5.0"


### PR DESCRIPTION
the NTT dashboard uses an NttOwner contract to own the ntt deployment, in order to faciliate the calling of setPeers in one transaction instead of multiple. 

this is good, however, the cli does not support this. 

this pr adds two things:

1. an additional flag to allow the skipping of chains in push. this is important if the owner of one side of the deployment does not have control over another side, but would like to update their limites

2. by checking using eip165, we can determine if the owner implements INttOwner. if it does, then we provide an alternative route to signSendWait using type assertions. 


this is still wip though, as the same override must be set for pushDeployment, and it is not yet set.

really what should happen is i should create a version of signSendWait for each chain that is aware of the ownership status, and can override the same way i am here. this way, we can reuse that same logic for pushDeployment.