### PR TITLE
solana: Prevent `rent_payer` from being overwritten in consecutive `set_token_authority` calls

### DIFF
--- a/solana/programs/example-native-token-transfers/src/instructions/admin/transfer_token_authority.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin/transfer_token_authority.rs
@@ -199,7 +199,12 @@ pub fn set_token_authority(ctx: Context<SetTokenAuthorityChecked>) -> Result<()>
         .set_inner(PendingTokenAuthority {
             bump: ctx.bumps.pending_token_authority,
             pending_authority: ctx.accounts.common.new_authority.key(),
-            rent_payer: ctx.accounts.rent_payer.key(),
+            rent_payer: if ctx.accounts.pending_token_authority.rent_payer != Pubkey::default() {
+                // do not update rent_payer if already initialized
+                ctx.accounts.pending_token_authority.rent_payer
+            } else {
+                ctx.accounts.rent_payer.key()
+            },
         });
     Ok(())
 }


### PR DESCRIPTION
Currently, it is possible to call `set_token_authority` twice consecutively - first time to initialize the `pending_token_authority` account and second time to update the `rent_payer`. This could result in the `rent_payer` being overwritten to the latest account instead of the actual rent payer. This PR fixes that by only setting `rent_payer` if `pending_token_authority` account is not previously initialized.