### PR TITLE
solana: Ensure `SetPeerArgs.chain_id != config.chain_id` in `set_peer`

### DIFF
--- a/solana/programs/example-native-token-transfers/src/instructions/admin/mod.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin/mod.rs
@@ -27,6 +27,7 @@ pub struct SetPeer<'info> {
 
     #[account(
         has_one = owner,
+        constraint = args.chain_id != config.chain_id @ NTTError::InvalidChainId
     )]
     pub config: Account<'info, Config>,
 


### PR DESCRIPTION
This PR adds constraint to ensure `SetPeerArgs.chain_id != config.chain_id`