### PR TITLE
solana: Remove unused `transceiver` account in `DeregisterTransceiver` struct

### DIFF
--- a/solana/programs/example-native-token-transfers/src/instructions/admin/mod.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin/mod.rs
@@ -151,13 +151,8 @@ pub struct DeregisterTransceiver<'info> {
 
     pub owner: Signer<'info>,
 
-    #[account(executable)]
-    /// CHECK: transceiver is meant to be a transceiver program. Arguably a `Program` constraint could be
-    /// used here that wraps the Transceiver account type.
-    pub transceiver: UncheckedAccount<'info>,
-
     #[account(
-        seeds = [RegisteredTransceiver::SEED_PREFIX, transceiver.key().as_ref()],
+        seeds = [RegisteredTransceiver::SEED_PREFIX, registered_transceiver.transceiver_address.as_ref()],
         bump,
         constraint = config.enabled_transceivers.get(registered_transceiver.id)? @ NTTError::DisabledTransceiver,
     )]

--- a/solana/programs/example-native-token-transfers/tests/sdk/instructions/admin.rs
+++ b/solana/programs/example-native-token-transfers/tests/sdk/instructions/admin.rs
@@ -85,7 +85,6 @@ pub fn deregister_transceiver(ntt: &NTT, accounts: DeregisterTransceiver) -> Ins
     let accounts = example_native_token_transfers::accounts::DeregisterTransceiver {
         config: ntt.config(),
         owner: accounts.owner,
-        transceiver: accounts.transceiver,
         registered_transceiver: ntt.registered_transceiver(&accounts.transceiver),
     };
 

--- a/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
+++ b/solana/ts/idl/3_0_0/json/example_native_token_transfers.json
@@ -1212,14 +1212,6 @@
           "isSigner": true
         },
         {
-          "name": "transceiver",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "used here that wraps the Transceiver account type."
-          ]
-        },
-        {
           "name": "registeredTransceiver",
           "isMut": false,
           "isSigner": false

--- a/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
+++ b/solana/ts/idl/3_0_0/ts/example_native_token_transfers.ts
@@ -1212,14 +1212,6 @@ export type ExampleNativeTokenTransfers = {
           "isSigner": true
         },
         {
-          "name": "transceiver",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "used here that wraps the Transceiver account type."
-          ]
-        },
-        {
           "name": "registeredTransceiver",
           "isMut": false,
           "isSigner": false
@@ -3710,14 +3702,6 @@ export const IDL: ExampleNativeTokenTransfers = {
           "name": "owner",
           "isMut": false,
           "isSigner": true
-        },
-        {
-          "name": "transceiver",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "used here that wraps the Transceiver account type."
-          ]
         },
         {
           "name": "registeredTransceiver",

--- a/solana/ts/sdk/ntt.ts
+++ b/solana/ts/sdk/ntt.ts
@@ -763,7 +763,6 @@ export class SolanaNtt<N extends Network, C extends SolanaChains>
       .accountsStrict({
         owner,
         config: this.pdas.configAccount(),
-        transceiver: transceiverProgramId,
         registeredTransceiver:
           this.pdas.registeredTransceiver(transceiverProgramId),
       })


### PR DESCRIPTION
The `transceiver` account is not required in the `deregister_transceiver` instruction - it could be replaced using `registered_transceiver.transceiver_address` to generate the seed. 
This PR removes the unused account and updates the Rust test, TS SDK helper, and IDL as a result.