### PR TITLE
solana: Skip upgrade authority CPI if current owner is `upgrade_lock`

### DIFF
--- a/solana/programs/example-native-token-transfers/src/instructions/admin/transfer_ownership.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin/transfer_ownership.rs
@@ -58,7 +58,7 @@ pub fn transfer_ownership(ctx: Context<TransferOwnership>) -> Result<()> {
     // only transfer authority when the authority is not already the upgrade lock
     if ctx.accounts.program_data.upgrade_authority_address != Some(ctx.accounts.upgrade_lock.key())
     {
-        bpf_loader_upgradeable::set_upgrade_authority_checked(
+        return bpf_loader_upgradeable::set_upgrade_authority_checked(
             CpiContext::new_with_signer(
                 ctx.accounts
                     .bpf_loader_upgradeable_program
@@ -71,10 +71,9 @@ pub fn transfer_ownership(ctx: Context<TransferOwnership>) -> Result<()> {
                 &[&[b"upgrade_lock", &[ctx.bumps.upgrade_lock]]],
             ),
             &crate::ID,
-        )
-    } else {
-        Ok(())
+        );
     }
+    Ok(())
 }
 
 pub fn transfer_ownership_one_step_unchecked(ctx: Context<TransferOwnership>) -> Result<()> {

--- a/solana/programs/example-native-token-transfers/src/instructions/admin/transfer_ownership.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin/transfer_ownership.rs
@@ -55,21 +55,26 @@ pub struct TransferOwnership<'info> {
 pub fn transfer_ownership(ctx: Context<TransferOwnership>) -> Result<()> {
     ctx.accounts.config.pending_owner = Some(ctx.accounts.new_owner.key());
 
-    // TODO: only transfer authority when the authority is not already the upgrade lock
-    bpf_loader_upgradeable::set_upgrade_authority_checked(
-        CpiContext::new_with_signer(
-            ctx.accounts
-                .bpf_loader_upgradeable_program
-                .to_account_info(),
-            bpf_loader_upgradeable::SetUpgradeAuthorityChecked {
-                program_data: ctx.accounts.program_data.to_account_info(),
-                current_authority: ctx.accounts.owner.to_account_info(),
-                new_authority: ctx.accounts.upgrade_lock.to_account_info(),
-            },
-            &[&[b"upgrade_lock", &[ctx.bumps.upgrade_lock]]],
-        ),
-        &crate::ID,
-    )
+    // only transfer authority when the authority is not already the upgrade lock
+    if ctx.accounts.program_data.upgrade_authority_address != Some(ctx.accounts.upgrade_lock.key())
+    {
+        bpf_loader_upgradeable::set_upgrade_authority_checked(
+            CpiContext::new_with_signer(
+                ctx.accounts
+                    .bpf_loader_upgradeable_program
+                    .to_account_info(),
+                bpf_loader_upgradeable::SetUpgradeAuthorityChecked {
+                    program_data: ctx.accounts.program_data.to_account_info(),
+                    current_authority: ctx.accounts.owner.to_account_info(),
+                    new_authority: ctx.accounts.upgrade_lock.to_account_info(),
+                },
+                &[&[b"upgrade_lock", &[ctx.bumps.upgrade_lock]]],
+            ),
+            &crate::ID,
+        )
+    } else {
+        Ok(())
+    }
 }
 
 pub fn transfer_ownership_one_step_unchecked(ctx: Context<TransferOwnership>) -> Result<()> {


### PR DESCRIPTION
This PR adds a check to ensure current owner is not `upgrade_lock` and only then performs the CPI call to `set_upgrade_authority_checked`. 