### PR TITLE
ci:  Use `release.anza.xyz` instead of `release.solana.com` to install Solana CLI

### DIFF
--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           SOLANA_VERSION: ${{ steps.solana.outputs.version }}
         run: |
-          sh -c "$(curl -sSfL https://release.solana.com/v${SOLANA_VERSION}/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v${SOLANA_VERSION}/install)"
           ~/.local/share/solana/install/active_release/bin/sdk/sbf/scripts/install.sh
 
       - name: cargo build-sbf && cargo test-sbf && cargo test


### PR DESCRIPTION
Solana CI jobs using `release.solana.com` to install Solana CLI seem to fail with `solana-keygen: command not found` error as `https://release.solana.com` is not accessible. This PR updates CI to use `https://release.anza.xyz` instead