### PR TITLE
solana: Have `written_size` match actual size written for `TransceiverMessage`, `WormholeTransceiverInfo`, and `WormholeTransceiverRegistration`

### DIFF
--- a/solana/modules/ntt-messages/src/transceiver.rs
+++ b/solana/modules/ntt-messages/src/transceiver.rs
@@ -177,8 +177,11 @@ where
     fn written_size(&self) -> usize {
         4 // prefix
         + self.source_ntt_manager.len()
+        + self.recipient_ntt_manager.len()
         + u16::SIZE.unwrap() // length prefix
         + self.ntt_manager_payload.written_size()
+        + u16::SIZE.unwrap() // length prefix
+        + self.transceiver_payload.len()
     }
 
     fn write<W>(&self, writer: &mut W) -> io::Result<()>

--- a/solana/modules/ntt-messages/src/transceivers/wormhole.rs
+++ b/solana/modules/ntt-messages/src/transceivers/wormhole.rs
@@ -77,7 +77,7 @@ impl Readable for WormholeTransceiverInfo {
 
 impl Writeable for WormholeTransceiverInfo {
     fn written_size(&self) -> usize {
-        WormholeTransceiverInfo::SIZE.unwrap()
+        WormholeTransceiver::INFO_PREFIX.len() + WormholeTransceiverInfo::SIZE.unwrap()
     }
 
     fn write<W>(&self, writer: &mut W) -> std::io::Result<()>
@@ -146,7 +146,7 @@ impl Readable for WormholeTransceiverRegistration {
 
 impl Writeable for WormholeTransceiverRegistration {
     fn written_size(&self) -> usize {
-        WormholeTransceiverRegistration::SIZE.unwrap()
+        WormholeTransceiver::PEER_INFO_PREFIX.len() + WormholeTransceiverRegistration::SIZE.unwrap()
     }
 
     fn write<W>(&self, writer: &mut W) -> std::io::Result<()>


### PR DESCRIPTION
Compared to the actual size written, `written_size` omits:
* `recipient_ntt_manager.len()` and `(2 + transceiver_payload.len())` for `TransceiverMessage
* 4 bytes for the PREFIX for `WormholeTransceiverInfo` and `WormholeTransceiverRegistration`
This PR fixes that by accounting for the omitted lengths.