### PR TITLE
chore: Update GitHub repo links pointing to old repo name

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -9,7 +9,7 @@ if ! command -v bun > /dev/null; then
   exit 1
 fi
 
-REPO="https://github.com/wormhole-foundation/example-native-token-transfers.git"
+REPO="https://github.com/wormhole-foundation/native-token-transfers.git"
 
 function main {
   branch=""

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -269,7 +269,7 @@ yargs(hideBin(process.argv))
                 if (argv["repo"]) {
                     repoArg = `--repo ${argv["repo"]}`;
                 }
-                const installScript = "https://raw.githubusercontent.com/wormhole-foundation/example-native-token-transfers/main/cli/install.sh";
+                const installScript = "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/cli/install.sh";
                 // save it to "$HOME/.ntt-cli/install.sh"
                 const nttDir = `${process.env.HOME}/.ntt-cli`;
                 const installer = `${nttDir}/install.sh`;
@@ -297,7 +297,7 @@ yargs(hideBin(process.argv))
                 process.exit(1);
             }
             const path = argv["path"];
-            await $`git clone -b main https://github.com/wormhole-foundation/example-native-token-transfers.git ${path}`;
+            await $`git clone -b main https://github.com/wormhole-foundation/native-token-transfers.git ${path}`;
         })
     .command("add-chain <chain>",
         "add a chain to the deployment file",

--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wormhole-foundation/example-native-token-transfers.git"
+    "url": "git+https://github.com/wormhole-foundation/native-token-transfers.git"
   },
   "bugs": {
-    "url": "https://github.com/wormhole-foundation/example-native-token-transfers"
+    "url": "https://github.com/wormhole-foundation/native-token-transfers"
   },
   "directories": {
     "test": "__tests__"

--- a/sdk/definitions/package.json
+++ b/sdk/definitions/package.json
@@ -3,12 +3,12 @@
   "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wormhole-foundation/example-native-token-transfers.git"
+    "url": "git+https://github.com/wormhole-foundation/native-token-transfers.git"
   },
   "bugs": {
-    "url": "https://github.com/wormhole-foundation/example-native-token-transfers"
+    "url": "https://github.com/wormhole-foundation/native-token-transfers"
   },
-  "homepage": "https://github.com/wormhole-foundation/example-native-token-transfers#readme",
+  "homepage": "https://github.com/wormhole-foundation/native-token-transfers#readme",
   "directories": {
     "test": "__tests__"
   },

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -3,12 +3,12 @@
   "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wormhole-foundation/example-native-token-transfers.git"
+    "url": "git+https://github.com/wormhole-foundation/native-token-transfers.git"
   },
   "bugs": {
-    "url": "https://github.com/wormhole-foundation/example-native-token-transfers"
+    "url": "https://github.com/wormhole-foundation/native-token-transfers"
   },
-  "homepage": "https://github.com/wormhole-foundation/example-native-token-transfers#readme",
+  "homepage": "https://github.com/wormhole-foundation/native-token-transfers#readme",
   "directories": {
     "test": "__tests__"
   },

--- a/solana/package.json
+++ b/solana/package.json
@@ -3,12 +3,12 @@
   "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wormhole-foundation/example-native-token-transfers.git"
+    "url": "git+https://github.com/wormhole-foundation/native-token-transfers.git"
   },
   "bugs": {
-    "url": "https://github.com/wormhole-foundation/example-native-token-transfers"
+    "url": "https://github.com/wormhole-foundation/native-token-transfers"
   },
-  "homepage": "https://github.com/wormhole-foundation/example-native-token-transfers#readme",
+  "homepage": "https://github.com/wormhole-foundation/native-token-transfers#readme",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
This PR replace GitHub links pointing to the old repo name (`../wormhole-foundation/example-native-token-transfers`) with ones pointing to the new repo name (`../wormhole-foundation/native-token-transfers`) for the `cli`, `solana`, `evm`, and `sdk` directory files and packages.