### PR TITLE
solana: Deactivate direct mapping feature for testing to detect stack frame issues

### DIFF
--- a/solana/Anchor.toml
+++ b/solana/Anchor.toml
@@ -38,6 +38,7 @@ url = "https://api.mainnet-beta.solana.com"
 ledger = ".anchor/test-ledger"
 rpc_port = 8899
 ticks_per_slot = 16
+deactivate_feature = ["GJVDwRkUPNdk9QaK4VsU4g1N41QNxhy1hevjf8kz45Mq", "EenyoWx9UMXYKpR8mW5Jmfmy2fRjzUtM7NduYMY8bx33"]
 
 [[test.validator.account]]
 address = "2yVjuQwpsvdsrywzsJJVs9Ueh4zayyo5DYJbBNc3DDpn"


### PR DESCRIPTION
This feature is not enabled on mainnet. Thus, we deactivate it to ensure stack and heap limits are as expected.