### PR TITLE
cli: add executor support

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.0",
   "module": "src/index.ts",
   "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
   "devDependencies": {
     "@types/bun": "latest",
     "@types/yargs": "^17.0.32"

--- a/cli/src/diff.ts
+++ b/cli/src/diff.ts
@@ -43,7 +43,7 @@ export function diffObjects<T extends Record<string, any>>(obj1: T, obj2: T): Pa
     // prune empty objects
     for (const key in result) {
         if (isObject(result[key])) {
-            if (Object.keys(result[key]).length === 0) {
+            if (result[key] && Object.keys(result[key] as object).length === 0) {
                 delete result[key];
             }
         }

--- a/cli/src/evmsigner.ts
+++ b/cli/src/evmsigner.ts
@@ -136,22 +136,12 @@ export class EvmNativeSigner<N extends Network, C extends EvmChains = EvmChains>
         feeData.maxPriorityFeePerGas ?? maxPriorityFeePerGas;
     }
 
-    // Oasis throws malformed errors unless we
-    // set it to use legacy transaction parameters
-    const gasOpts =
-      chain === 'Oasis'
-        ? {
-            gasLimit,
-            gasPrice: gasPrice,
-            // Hardcode type
-            type: 0,
-          }
-        : {
-            gasPrice,
-            maxFeePerGas,
-            maxPriorityFeePerGas,
-            gasLimit,
-          };
+    const gasOpts = {
+      gasPrice,
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+      gasLimit,
+    };
 
     // TODO: DIFF ENDS HERE
 

--- a/cli/src/getSigner.ts
+++ b/cli/src/getSigner.ts
@@ -62,6 +62,7 @@ export async function getSigner<N extends Network, C extends Chain>(
                         }
                         privateKey = privateKeySource;
                     }
+                    source = privateKey;
                     signer = await solana.getSigner(
                         await chain.getRpc(),
                         privateKey,

--- a/cli/src/types.d.ts
+++ b/cli/src/types.d.ts
@@ -1,0 +1,6 @@
+// Type declarations for Bun-specific imports
+
+declare module "*.sol" {
+  const content: string;
+  export default content;
+}

--- a/cli/test/sepolia-bsc.sh
+++ b/cli/test/sepolia-bsc.sh
@@ -30,7 +30,7 @@ wait_for_rpc() {
   local url=$1
   local max_attempts=30
   local attempt=1
-  
+
   echo "Waiting for RPC endpoint $url to be ready..."
   while [ $attempt -le $max_attempts ]; do
     if curl -s -X POST "$url" \
@@ -87,7 +87,7 @@ cat <<EOF > overrides.json
 }
 EOF
 
-ntt add-chain Bsc --token 0x0B15635FCF5316EdFD2a9A0b0dC3700aeA4D09E6 --mode locking --skip-verify --latest
+ntt add-chain Bsc --token 0x0B15635FCF5316EdFD2a9A0b0dC3700aeA4D09E6 --mode locking --skip-verify --latest --no-executor
 ntt add-chain Sepolia --token 0xB82381A3fBD3FaFA77B3a7bE693342618240067b --skip-verify --ver 1.0.0
 
 ntt pull --yes

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "rebuild": "npm run rebuild --workspaces --if-present",
     "build:solana": "npm run build --workspace=sdk/definitions --workspace=solana",
     "build:evm": "npm run build --workspace=sdk/definitions --workspace=sdk/evm",
+    "typecheck:cli": "npm run typecheck --workspace=cli",
     "generate": "npm run generate --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "test:ci": "CI=true jest --config ./jest.config.ts",


### PR DESCRIPTION
This makes it so the EVM deployments don't enable standard/special relaying on the WH transceiver when the executor flag is set to true in the config.