### PR TITLE
solana: Deterministic builds via Docker

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -12,7 +12,7 @@ docker_build(
     context = "./",
     only = ["./sdk", "./solana"],
     ignore=["./sdk/__tests__", "./sdk/Dockerfile", "./sdk/ci.yaml", "./sdk/**/dist", "./sdk/node_modules", "./sdk/**/node_modules"],
-    target = "builder",
+    target = "dev-builder",
     dockerfile = "./solana/Dockerfile",
 )
 docker_build(
@@ -44,7 +44,7 @@ docker_build(
     only=["./sdk", "./package.json", "./package-lock.json", "jest.config.ts", "tsconfig.json", "tsconfig.esm.json", "tsconfig.cjs.json", "tsconfig.test.json"],
     dockerfile = "./sdk/Dockerfile",
 )
-k8s_yaml_with_ns("./sdk/ci.yaml") 
+k8s_yaml_with_ns("./sdk/ci.yaml")
 k8s_resource(
     "ntt-ci-tests",
     labels = ["ntt"],

--- a/Tiltfile
+++ b/Tiltfile
@@ -12,7 +12,7 @@ docker_build(
     context = "./",
     only = ["./sdk", "./solana"],
     ignore=["./sdk/__tests__", "./sdk/Dockerfile", "./sdk/ci.yaml", "./sdk/**/dist", "./sdk/node_modules", "./sdk/**/node_modules"],
-    target = "dev-builder",
+    target = "builder",
     dockerfile = "./solana/Dockerfile",
 )
 docker_build(

--- a/solana/.gitignore
+++ b/solana/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 test-ledger
 dist
+artifacts-*

--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -45,13 +45,13 @@ RUN make target/idl/example_native_token_transfers.json
 
 FROM scratch AS export
 
-COPY --from=dev-builder /opt/solana/deps /opt/solana/deps
-COPY --from=dev-builder /usr/src/solana/ts /usr/src/solana/ts
-COPY --from=dev-builder /usr/src/solana/package.json /usr/src/solana/package.json
-COPY --from=dev-builder /usr/src/solana/tsconfig.esm.json /usr/src/solana/tsconfig.esm.json
-COPY --from=dev-builder /usr/src/solana/tsconfig.cjs.json /usr/src/solana/tsconfig.cjs.json
-COPY --from=dev-builder /usr/src/solana/target/idl  /usr/src/solana/target/idl
-COPY --from=dev-builder /usr/src/solana/target/types /usr/src/solana/target/types
+COPY --from=builder /opt/solana/deps /opt/solana/deps
+COPY --from=builder /usr/src/solana/ts /usr/src/solana/ts
+COPY --from=builder /usr/src/solana/package.json /usr/src/solana/package.json
+COPY --from=builder /usr/src/solana/tsconfig.esm.json /usr/src/solana/tsconfig.esm.json
+COPY --from=builder /usr/src/solana/tsconfig.cjs.json /usr/src/solana/tsconfig.cjs.json
+COPY --from=builder /usr/src/solana/target/idl  /usr/src/solana/target/idl
+COPY --from=builder /usr/src/solana/target/types /usr/src/solana/target/types
 
 FROM node:lts-alpine@sha256:41e4389f3d988d2ed55392df4db1420ad048ae53324a8e2b7c6d19508288107e AS governance
 

--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -8,11 +8,10 @@ COPY solana/Cargo.toml Cargo.toml
 COPY solana/modules modules
 COPY solana/programs programs
 COPY solana/rust-toolchain rust-toolchain
-COPY solana/scripts scripts
 
 ENV RUST_BACKTRACE=1
 
-FROM anchor AS dev-builder
+FROM anchor AS builder
 
 RUN mkdir -p /opt/solana/deps
 
@@ -33,15 +32,18 @@ RUN cp ./target/sbf-solana-solana/release/example_native_token_transfers.so /opt
 
 COPY solana/tilt /opt/solana/deps
 
+COPY sdk ../sdk
 COPY solana/ts ts
 COPY solana/package.json package.json
 COPY solana/tsconfig.esm.json tsconfig.esm.json
 COPY solana/tsconfig.cjs.json tsconfig.cjs.json
 COPY solana/tsconfig.anchor.json tsconfig.anchor.json
 COPY solana/Makefile Makefile
+COPY solana/scripts scripts
+
 RUN make target/idl/example_native_token_transfers.json
 
-FROM scratch AS dev-export
+FROM scratch AS export
 
 COPY --from=dev-builder /opt/solana/deps /opt/solana/deps
 COPY --from=dev-builder /usr/src/solana/ts /usr/src/solana/ts
@@ -50,20 +52,6 @@ COPY --from=dev-builder /usr/src/solana/tsconfig.esm.json /usr/src/solana/tsconf
 COPY --from=dev-builder /usr/src/solana/tsconfig.cjs.json /usr/src/solana/tsconfig.cjs.json
 COPY --from=dev-builder /usr/src/solana/target/idl  /usr/src/solana/target/idl
 COPY --from=dev-builder /usr/src/solana/target/types /usr/src/solana/target/types
-
-FROM anchor AS mainnet-builder
-
-ARG SOLANA_NETWORK
-RUN [ -z "$SOLANA_NETWORK" ] && echo "SOLANA_NETWORK is required" && exit 1 || echo "SOLANA_NETWORK=$SOLANA_NETWORK"
-
-RUN --mount=type=cache,target=/opt/solana/deps/target,id=build_anchor_ntt_target \
-    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
-    --mount=type=cache,target=.anchor,id=anchor_cache \
-    anchor build --arch sbf -- --no-default-features --features $SOLANA_NETWORK
-
-FROM scratch AS mainnet-export
-
-COPY --from=mainnet-builder /usr/src/solana/target/deploy /
 
 FROM node:lts-alpine@sha256:41e4389f3d988d2ed55392df4db1420ad048ae53324a8e2b7c6d19508288107e AS governance
 

--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -8,10 +8,11 @@ COPY solana/Cargo.toml Cargo.toml
 COPY solana/modules modules
 COPY solana/programs programs
 COPY solana/rust-toolchain rust-toolchain
+COPY solana/scripts scripts
 
 ENV RUST_BACKTRACE=1
 
-FROM anchor AS builder
+FROM anchor AS dev-builder
 
 RUN mkdir -p /opt/solana/deps
 
@@ -32,26 +33,37 @@ RUN cp ./target/sbf-solana-solana/release/example_native_token_transfers.so /opt
 
 COPY solana/tilt /opt/solana/deps
 
-COPY sdk ../sdk
-COPY solana/ts ts 
+COPY solana/ts ts
 COPY solana/package.json package.json
 COPY solana/tsconfig.esm.json tsconfig.esm.json
 COPY solana/tsconfig.cjs.json tsconfig.cjs.json
 COPY solana/tsconfig.anchor.json tsconfig.anchor.json
 COPY solana/Makefile Makefile
-COPY solana/scripts scripts
-
 RUN make target/idl/example_native_token_transfers.json
 
-FROM scratch AS export
+FROM scratch AS dev-export
 
-COPY --from=builder /opt/solana/deps /opt/solana/deps
-COPY --from=builder /usr/src/solana/ts /usr/src/solana/ts
-COPY --from=builder /usr/src/solana/package.json /usr/src/solana/package.json
-COPY --from=builder /usr/src/solana/tsconfig.esm.json /usr/src/solana/tsconfig.esm.json
-COPY --from=builder /usr/src/solana/tsconfig.cjs.json /usr/src/solana/tsconfig.cjs.json
-COPY --from=builder /usr/src/solana/target/idl  /usr/src/solana/target/idl 
-COPY --from=builder /usr/src/solana/target/types /usr/src/solana/target/types
+COPY --from=dev-builder /opt/solana/deps /opt/solana/deps
+COPY --from=dev-builder /usr/src/solana/ts /usr/src/solana/ts
+COPY --from=dev-builder /usr/src/solana/package.json /usr/src/solana/package.json
+COPY --from=dev-builder /usr/src/solana/tsconfig.esm.json /usr/src/solana/tsconfig.esm.json
+COPY --from=dev-builder /usr/src/solana/tsconfig.cjs.json /usr/src/solana/tsconfig.cjs.json
+COPY --from=dev-builder /usr/src/solana/target/idl  /usr/src/solana/target/idl
+COPY --from=dev-builder /usr/src/solana/target/types /usr/src/solana/target/types
+
+FROM anchor AS mainnet-builder
+
+ARG SOLANA_NETWORK
+RUN [ -z "$SOLANA_NETWORK" ] && echo "SOLANA_NETWORK is required" && exit 1 || echo "SOLANA_NETWORK=$SOLANA_NETWORK"
+
+RUN --mount=type=cache,target=/opt/solana/deps/target,id=build_anchor_ntt_target \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
+    --mount=type=cache,target=.anchor,id=anchor_cache \
+    anchor build --arch sbf -- --no-default-features --features $SOLANA_NETWORK
+
+FROM scratch AS mainnet-export
+
+COPY --from=mainnet-builder /usr/src/solana/target/deploy /
 
 FROM node:lts-alpine@sha256:41e4389f3d988d2ed55392df4db1420ad048ae53324a8e2b7c6d19508288107e AS governance
 

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -30,23 +30,17 @@ anchor-build:
 prod-build:
 	anchor build --verifiable
 
-artifacts-mainnet: NETWORK=mainnet
-artifacts-mainnet: _artifacts
-	mv _artifacts $@
+artifacts-mainnet: 
+	$(MAKE) _artifacts TARGET_DIR=$@ NETWORK=mainnet
 
-artifacts-solana-devnet: NETWORK=solana-devnet
-artifacts-solana-devnet: _artifacts
-	mv _artifacts $@
+artifacts-solana-devnet:
+	$(MAKE) _artifacts TARGET_DIR=$@ NETWORK=solana-devnet
 
-artifacts-tilt-devnet: NETWORK=tilt-devnet
-artifacts-tilt-devnet: _artifacts
-	mv _artifacts $@
+artifacts-tilt-devnet:
+	$(MAKE) _artifacts TARGET_DIR=$@ NETWORK=tilt-devnet
 
 _artifacts:
-	rm -rf $@
-	DOCKER_BUILDKIT=1 cd .. && docker build -f solana/Dockerfile --build-arg="SOLANA_NETWORK=$(NETWORK)" -t export -o solana/$@ .
-	@cd $@ && ls | xargs sha256sum > checksums.txt
-	@cat $@/checksums.txt
+	solana-verify build -- --no-default-features --features $(NETWORK) --target-dir $(TARGET_DIR)
 
 idl: anchor-build
 	@echo "IDL Version: $(VERSION)"

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL = build
-.PHONY: build cargo-build anchor-build prod-build test cargo-test anchor-test idl sdk clean node_modules lint cargo-lint anchor-lint fix-lint
+.PHONY: build cargo-build anchor-build prod-build artifacts-mainnet artifacts-solana-devnet artifacts-tilt-devnet _artifacts test cargo-test anchor-test idl sdk clean node_modules lint cargo-lint anchor-lint fix-lint
 
 # Find and convert version line:
 #  Turn `const VERSION: &str = "major.minor.patch";` into `major_minor_patch`
@@ -29,6 +29,24 @@ anchor-build:
 
 prod-build:
 	anchor build --verifiable
+
+artifacts-mainnet: NETWORK=mainnet
+artifacts-mainnet: _artifacts
+	mv _artifacts $@
+
+artifacts-solana-devnet: NETWORK=solana-devnet
+artifacts-solana-devnet: _artifacts
+	mv _artifacts $@
+
+artifacts-tilt-devnet: NETWORK=tilt-devnet
+artifacts-tilt-devnet: _artifacts
+	mv _artifacts $@
+
+_artifacts:
+	rm -rf $@
+	DOCKER_BUILDKIT=1 cd .. && docker build -f solana/Dockerfile --build-arg="SOLANA_NETWORK=$(NETWORK)" -t export -o solana/$@ .
+	@cd $@ && ls | xargs sha256sum > checksums.txt
+	@cat $@/checksums.txt
 
 idl: anchor-build
 	@echo "IDL Version: $(VERSION)"

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL = build
-.PHONY: build cargo-build anchor-build prod-build artifacts-mainnet artifacts-solana-devnet artifacts-tilt-devnet _artifacts test cargo-test anchor-test idl sdk clean node_modules lint cargo-lint anchor-lint fix-lint
+.PHONY: build cargo-build anchor-build artifacts-mainnet artifacts-solana-devnet artifacts-tilt-devnet _artifacts test cargo-test anchor-test idl sdk clean node_modules lint cargo-lint anchor-lint fix-lint
 
 # Find and convert version line:
 #  Turn `const VERSION: &str = "major.minor.patch";` into `major_minor_patch`

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -27,9 +27,6 @@ anchor-build:
 	  ./scripts/patch-idl $$jsonfile; \
 	done
 
-prod-build:
-	anchor build --verifiable
-
 artifacts-mainnet: 
 	$(MAKE) _artifacts TARGET_DIR=$@ NETWORK=mainnet
 

--- a/solana/README.md
+++ b/solana/README.md
@@ -144,6 +144,21 @@ Run the following command to install necessary dependencies and to build the pro
 make build
 ```
 
+For building the mainnet binaries, the only requirements are `docker` and `make`:
+
+```sh
+make artifacts-mainnet
+```
+
+which will produce the object files into the `artifacts-mainnet` directory. This is the recommended way of building the binaries as it results in deterministic builds.
+
+For Solana devnet builds, or local testing builds, use the following commands:
+
+```sh
+make artifacts-solana-devnet
+make artifacts-tilt-devnet
+```
+
 ### Test
 
 Run the following command to generate the IDL and run the full Solana test-suite:

--- a/solana/README.md
+++ b/solana/README.md
@@ -144,13 +144,17 @@ Run the following command to install necessary dependencies and to build the pro
 make build
 ```
 
-For building the mainnet binaries, the only requirements are `docker` and `make`:
+#### Verifiable Builds
+
+For building verifiably, make sure [`solana-verify`](https://crates.io/crates/solana-verify) is installed and Docker is installed and running.
+
+Run the following command to build the program binaries deterministically for `mainnet`:
 
 ```sh
 make artifacts-mainnet
 ```
 
-which will produce the object files into the `artifacts-mainnet` directory. This is the recommended way of building the binaries as it results in deterministic builds.
+> This will produce the generated artifacts in the `artifacts-mainnet` directory.
 
 For Solana devnet builds, or local testing builds, use the following commands:
 


### PR DESCRIPTION
This PR was initially based on https://github.com/wormhole-foundation/native-token-transfers/pull/403. However, due to reasons mentioned in [this comment](https://github.com/wormhole-foundation/native-token-transfers/pull/646#issuecomment-3014103037), the Dockerfile changes were reverted.

tl;dr: 
This PR adds:
* Add `artifacts-mainnet`, `artifacts-solana-devnet`, and `artifacts-tilt-devnet` Makefile target to generate verifiable build artifacts using `solana-verify build`
* Remove `prod-build` Makefile target

