### PR TITLE
Fix nonce synchronization issues in EVM deployments by adding slow flag to forge

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1470,7 +1470,7 @@ async function upgradeEvm<N extends Network, C extends EvmChains>(
 --sig "upgrade(address)" \
 ${ntt.managerAddress} \
 ${signerArgs} \
---broadcast \
+--broadcast --slow \
 ${verifyArgs} | tee last-run.stdout`, {
                 cwd: `${pwd}/evm`,
                 stdio: "inherit"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1601,7 +1601,7 @@ forge script --via-ir script/DeployWormholeNtt.s.sol \
 --rpc-url ${rpc} \
 ${simulateArg} \
 --sig "${sig}" ${wormhole} ${token} ${effectiveRelayer} ${specialRelayer} ${decimals} ${modeUint} \
---broadcast ${verifyArgs.join(' ')} ${signerArgs} 2>&1 | tee last-run.stdout`, {
+--broadcast --slow ${verifyArgs.join(' ')} ${signerArgs} 2>&1 | tee last-run.stdout`, {
                         cwd: `${pwd}/evm`,
                         encoding: 'utf8',
                         stdio: 'inherit'


### PR DESCRIPTION
EVM deployments were failing with nonce errors on certain networks (e.g. Mezo) due to forge sending transactions too quickly without waiting for confirmation between transactions.
Example error:
`server returned an error response: error code -32000: invalid nonce; got 3, expected 2: invalid sequence: invalid sequence`

Added --slow flag to forge script commands in both `deployEvm` and `upgradeEvm` functions. This flag forces forge to wait for transaction confirmation before sending the next one, ensuring proper nonce synchronization.
