### PR TITLE
add transfer ownership functionality for evm to the CLI

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1287,8 +1287,118 @@ yargs(hideBin(process.argv))
                 }
             }
         })
-    .command("solana",
-        "Solana commands",
+            .command("transfer-ownership <chain>",
+            "transfer NTT manager ownership to a new wallet (EVM chains only)",
+            (yargs) => yargs
+                .positional("chain", options.chain)
+                .option("destination", {
+                    describe: "New owner wallet address",
+                    type: "string",
+                    demandOption: true,
+                })
+                .option("path", options.deploymentPath)
+                .option("yes", options.yes)
+                .example(
+                    "$0 transfer-ownership Ethereum --destination 0x1234...",
+                    "Transfer NTT manager ownership on Ethereum to a new wallet"
+                )
+                .example(
+                    "$0 transfer-ownership Bsc --destination 0xabcd... --path ./my-deployment.json",
+                    "Transfer NTT manager ownership on BSC to a new wallet using custom deployment file"
+                ),
+            async (argv) => {
+                const path = argv["path"];
+                const deployments: Config = loadConfig(path);
+                const chain: Chain = argv["chain"];
+                const destination = argv["destination"];
+                const network = deployments.network as Network;
+
+                // Check that the platform is EVM
+                const platform = chainToPlatform(chain);
+                if (platform !== "Evm") {
+                    console.error(`transfer-ownership is only supported for EVM chains. Got platform: ${platform}`);
+                    process.exit(1);
+                }
+
+                if (!(chain in deployments.chains)) {
+                    console.error(`Chain ${chain} not found in deployment configuration`);
+                    process.exit(1);
+                }
+
+                const chainConfig = deployments.chains[chain]!;
+                console.log(`Transferring ownership on ${chain} (${network})`);
+                console.log(`Manager address: ${chainConfig.manager}`);
+                console.log(`New owner: ${destination}`);
+
+                // Validate destination address
+                if (!ethers.isAddress(destination)) {
+                    console.error("Invalid destination address");
+                    process.exit(1);
+                }
+
+                // Get NTT instance
+                const [, , ntt] = await pullChainConfig(
+                    network,
+                    { chain, address: toUniversal(chain, chainConfig.manager) },
+                    overrides
+                );
+
+                // Get current owner
+                const currentOwner = await ntt.getOwner();
+                console.log(`Current owner: ${currentOwner}`);
+
+                // Get signer using the same pattern as other commands
+                const wh = new Wormhole(network, [evm.Platform], overrides);
+                const ch = wh.getChain(chain);
+                const signer = await getSigner(ch, "privateKey");
+                
+                // Verify the wallet is the current owner
+                if (currentOwner.toString().toLowerCase() !== signer.address.address.toString().toLowerCase()) {
+                    console.error(`❌ Wallet ${signer.address.address} is not the current owner. Current owner is ${currentOwner}`);
+                    process.exit(1);
+                }
+
+                if (!argv["yes"]) {
+                    await askForConfirmation(`Are you sure you want to move the ownership over the NTT contracts over to ${destination}?`);
+                }
+
+                try {
+                    // Cast to EVM NTT and call transferOwnership
+                    const evmNtt = ntt as EvmNtt<typeof network, EvmChains>;
+                    
+                    // Get the native ethers signer from the EvmNativeSigner
+                    const nativeSigner = (signer.signer as any)._signer;
+                    if (!nativeSigner || !nativeSigner.provider) {
+                        throw new Error("Failed to get native ethers signer");
+                    }
+                    
+                            const contract = evmNtt.manager.connect(nativeSigner);
+                            const tx = await contract.transferOwnership(destination);
+                            console.log(`Transaction hash: ${tx.hash}`);
+                            console.log(`Waiting for 1 confirmation...`);
+                            
+                            // 1 confirmation, 5 minute timeout
+                            await tx.wait(1, 300000);
+                            
+                            console.log(`Verifying ownership transfer...`);
+                            const newOwnerFromContract = await evmNtt.manager.owner();
+                            if (newOwnerFromContract.toLowerCase() === destination.toLowerCase()) {
+                                console.log(`✅ Ownership transferred successfully to ${destination}`);
+                            } else {
+                                console.error(`❌ Ownership transfer verification failed`);
+                                process.exit(1);
+                            }
+                    
+                } catch (error: any) {
+                    console.error("❌ Failed to transfer ownership:", error.message);
+                    if (error.transaction) {
+                        console.error("Transaction details:", error.transaction);
+                    }
+                    process.exit(1);
+                }
+            })
+        .command("solana",
+            "Solana commands",
         (yargs) => {
             yargs
                 .command("key-base58 <keypair>",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1359,7 +1359,12 @@ yargs(hideBin(process.argv))
                 }
 
                 if (!argv["yes"]) {
-                    await askForConfirmation(`Are you sure you want to move the ownership over the NTT contracts over to ${destination}?`);
+                    console.log("\n⚠️  ⚠️  ⚠️  CRITICAL WARNING ⚠️  ⚠️  ⚠️");
+                    console.log("This ownership transfer is IRREVERSIBLE!");
+                    console.log("Please TRIPLE-CHECK that the destination address is correct:");
+                    console.log(`   ${destination}`);
+                    console.log("");
+                    await askForConfirmation(`Are you absolutely certain you want to transfer ownership to ${destination}?`);
                 }
 
                 try {
@@ -1386,6 +1391,7 @@ yargs(hideBin(process.argv))
                                 console.log(`✅ Ownership transferred successfully to ${destination}`);
                             } else {
                                 console.error(`❌ Ownership transfer verification failed`);
+                                console.error(`   New owner:        ${newOwnerFromContract}`);
                                 process.exit(1);
                             }
                     
@@ -2649,7 +2655,7 @@ async function askForConfirmation(prompt: string = "Do you want to continue?"): 
         output: process.stdout,
     });
     const answer = await new Promise<string>((resolve) => {
-        rl.question(`${prompt} [y/n]`, resolve);
+        rl.question(`${prompt} [y/N]`, resolve);
     });
     rl.close();
 


### PR DESCRIPTION
Example:

❯ ntt transfer-ownership Unichain --destination DESTIONATION_WALLET --path deployment.json

```
Transferring ownership on Unichain (Mainnet)
Manager address: NTT_MANAGER
New owner: DESTIONATION_WALLET
Current owner: CURRENT_OWNER_WALLET
Are you sure you want to move the ownership over the NTT contracts over to DESTIONATION_WALLET? [y/n]y
Transaction hash: 0xe3548
Waiting for 1 confirmation...
Verifying ownership transfer...
✅ Ownership transferred successfully to DESTIONATION_WALLET
```