### PR TITLE
evm: fix test_transceiverIncompatibleNttManager

### DIFF
--- a/evm/test/NttManager.t.sol
+++ b/evm/test/NttManager.t.sol
@@ -26,6 +26,8 @@ import "./mocks/DummyTransceiver.sol";
 import "../src/mocks/DummyToken.sol";
 import "./mocks/MockNttManager.sol";
 
+contract DummyManager {}
+
 // TODO: set this up so the common functionality tests can be run against both
 contract TestNttManager is Test, IRateLimiterEvents {
     MockNttManagerContract nttManager;
@@ -333,8 +335,9 @@ contract TestNttManager is Test, IRateLimiterEvents {
 
     function test_transceiverIncompatibleNttManager() public {
         // Transceiver instantiation reverts if the nttManager doesn't have the proper token method
+        address dummyManager = address(new DummyManager());
         vm.expectRevert(bytes(""));
-        new DummyTransceiver(address(0xBEEF));
+        new DummyTransceiver(dummyManager);
     }
 
     function test_transceiverWrongNttManager() public {

--- a/evm/test/NttManagerNoRateLimiting.t.sol
+++ b/evm/test/NttManagerNoRateLimiting.t.sol
@@ -259,12 +259,6 @@ contract TestNttManagerNoRateLimiting is Test, IRateLimiterEvents {
         nttManager.setTransceiver(address(e2));
     }
 
-    function test_transceiverIncompatibleNttManagerNoRateLimiting() public {
-        // Transceiver instantiation reverts if the nttManager doesn't have the proper token method
-        vm.expectRevert(bytes(""));
-        new DummyTransceiver(address(0xBEEF));
-    }
-
     function test_transceiverWrongNttManagerNoRateLimiting() public {
         // TODO: this is accepted currently. should we include a check to ensure
         // only transceivers whose nttManager is us can be registered? (this would be


### PR DESCRIPTION
This test started failing as of forge v1.3.1, specifically due to this PR https://github.com/foundry-rs/foundry/pull/10446.

The PR implements better error reporting *when the tests run in verbose mode*, so the test that previously expected an empty revert string now fails in verbose mode, because forge now returns an error about calling a contract with no bytecode.

Actually this test was supposed to test (according to the comment) that the transceiver constructor revert if the manager doesn't have the token method, but that's not what it was testing. So we change the test to actually use a dummy contract that has no token method. This returns an empty revert string, so everything is good. Until forge includes an override for that too at least