### PR TITLE
fix: Executor *transfer function should yield instead of return

### DIFF
--- a/sui/ts/src/nttWithExecutor.ts
+++ b/sui/ts/src/nttWithExecutor.ts
@@ -111,7 +111,7 @@ export class SuiNttWithExecutor<N extends Network, C extends SuiChains>
       "NTT Transfer with Executor"
     );
 
-    return executorTx;
+    yield executorTx;
   }
 
   private async createSuiNttTransferWithExecutor(


### PR DESCRIPTION
This was a regression during sui/implementation PR review.