### PR TITLE
Fix splitCoins call for non-native tokens

### DIFF
--- a/sui/ts/src/nttWithExecutor.ts
+++ b/sui/ts/src/nttWithExecutor.ts
@@ -403,7 +403,7 @@ export class SuiNttWithExecutor<N extends Network, C extends SuiChains>
   }
 
   // Helper function to split coins based on token type
-  private async splitCoinsByType(
+  async splitCoinsByType(
     tx: Transaction,
     sender: AccountAddress<C>,
     coinType: string,

--- a/sui/ts/src/nttWithExecutor.ts
+++ b/sui/ts/src/nttWithExecutor.ts
@@ -101,7 +101,6 @@ export class SuiNttWithExecutor<N extends Network, C extends SuiChains>
     const tx = await this.createSuiNttTransferWithExecutor(
       sender,
       destination,
-      amount,
       quote,
       ntt
     );
@@ -120,7 +119,6 @@ export class SuiNttWithExecutor<N extends Network, C extends SuiChains>
   private async createSuiNttTransferWithExecutor(
     sender: AccountAddress<C>,
     destination: ChainAddress,
-    amount: bigint,
     quote: NttWithExecutor.Quote,
     ntt: SuiNtt<N, C>
   ): Promise<Transaction> {
@@ -208,8 +206,8 @@ export class SuiNttWithExecutor<N extends Network, C extends SuiChains>
 
     // Split coins for transfer amount
     const [coin] = isNative
-      ? tx.splitCoins(tx.gas, [tx.pure.u64(amount)])
-      : tx.splitCoins(primaryCoinInput!, [tx.pure.u64(amount)]);
+      ? tx.splitCoins(tx.gas, [tx.pure.u64(quote.remainingAmount)])
+      : tx.splitCoins(primaryCoinInput!, [tx.pure.u64(quote.remainingAmount)]);
 
     // Create VersionGated object
     const [versionGated] = tx.moveCall({


### PR DESCRIPTION
- [x] Add isNative check to make sure we splitCoins for non-native tokens correctly.
- [x] Add unit tests for both cases.