### PR TITLE
Use borrow_inbox_item to retrieve inbox item

### DIFF
--- a/sui/ts/src/bcs-types.ts
+++ b/sui/ts/src/bcs-types.ts
@@ -1,37 +1,30 @@
 // BCS type definitions for NTT inbox items
-import { bcs, type BcsType } from '@mysten/bcs';
+import { bcs, type BcsType } from "@mysten/bcs";
 
-// Primitives/containers per docs:
-// - enums via bcs.enum
-// - structs via bcs.struct
-// - vector<u8> via bcs.vector(bcs.u8())
-// - Option<T> via bcs.option(T)
-
-// ---- leaf types ----
-const Bitmap = bcs.struct('Bitmap', { 
-  bitmap: bcs.u128() 
+const Bitmap = bcs.struct("Bitmap", {
+  bitmap: bcs.u128(),
 });
 
-const ReleaseStatus = bcs.enum('ReleaseStatus', {
+const ReleaseStatus = bcs.enum("ReleaseStatus", {
   NotApproved: null,
   ReleaseAfter: bcs.u64(),
   Released: null,
 });
 
-const TrimmedAmount = bcs.struct('TrimmedAmount', {
+const TrimmedAmount = bcs.struct("TrimmedAmount", {
   amount: bcs.u64(),
   decimals: bcs.u8(),
 });
 
-const Bytes32 = bcs.struct('Bytes32', { 
-  data: bcs.vector(bcs.u8())
+const Bytes32 = bcs.struct("Bytes32", {
+  data: bcs.vector(bcs.u8()),
 });
 
-const ExternalAddress = bcs.struct('ExternalAddress', { 
-  value: Bytes32 
+const ExternalAddress = bcs.struct("ExternalAddress", {
+  value: Bytes32,
 });
 
-const NativeTokenTransfer = bcs.struct('NativeTokenTransfer', {
+const NativeTokenTransfer = bcs.struct("NativeTokenTransfer", {
   amount: TrimmedAmount,
   source_token: ExternalAddress,
   to: ExternalAddress,
@@ -39,7 +32,6 @@ const NativeTokenTransfer = bcs.struct('NativeTokenTransfer', {
   payload: bcs.option(bcs.vector(bcs.u8())),
 });
 
-// ---- generic container ----
 function InboxItem<T extends BcsType<any>>(T: T) {
   return bcs.struct(`InboxItem<${T.name}>`, {
     votes: Bitmap,
@@ -48,9 +40,4 @@ function InboxItem<T extends BcsType<any>>(T: T) {
   });
 }
 
-// Concrete type:
 export const InboxItemNative = InboxItem(NativeTokenTransfer);
-
-// Export types for use in other files
-export type InboxItemNativeType = typeof InboxItemNative;
-export type ParsedInboxItem = ReturnType<typeof InboxItemNative.parse>;

--- a/sui/ts/src/bcs-types.ts
+++ b/sui/ts/src/bcs-types.ts
@@ -1,0 +1,56 @@
+// BCS type definitions for NTT inbox items
+import { bcs, type BcsType } from '@mysten/bcs';
+
+// Primitives/containers per docs:
+// - enums via bcs.enum
+// - structs via bcs.struct
+// - vector<u8> via bcs.vector(bcs.u8())
+// - Option<T> via bcs.option(T)
+
+// ---- leaf types ----
+const Bitmap = bcs.struct('Bitmap', { 
+  bitmap: bcs.u128() 
+});
+
+const ReleaseStatus = bcs.enum('ReleaseStatus', {
+  NotApproved: null,
+  ReleaseAfter: bcs.u64(),
+  Released: null,
+});
+
+const TrimmedAmount = bcs.struct('TrimmedAmount', {
+  amount: bcs.u64(),
+  decimals: bcs.u8(),
+});
+
+const Bytes32 = bcs.struct('Bytes32', { 
+  data: bcs.vector(bcs.u8())
+});
+
+const ExternalAddress = bcs.struct('ExternalAddress', { 
+  value: Bytes32 
+});
+
+const NativeTokenTransfer = bcs.struct('NativeTokenTransfer', {
+  amount: TrimmedAmount,
+  source_token: ExternalAddress,
+  to: ExternalAddress,
+  to_chain: bcs.u16(),
+  payload: bcs.option(bcs.vector(bcs.u8())),
+});
+
+// ---- generic container ----
+function InboxItem<T extends BcsType<any>>(T: T) {
+  return bcs.struct(`InboxItem<${T.name}>`, {
+    votes: Bitmap,
+    release_status: ReleaseStatus,
+    data: T,
+  });
+}
+
+// Concrete type:
+export const InboxItemNative = InboxItem(NativeTokenTransfer);
+
+// Export types for use in other files
+export type InboxItemNativeType = typeof InboxItemNative;
+export type ParsedInboxItem = ReturnType<typeof InboxItemNative.parse>;

--- a/sui/ts/src/utils.ts
+++ b/sui/ts/src/utils.ts
@@ -257,7 +257,9 @@ export function countSetBits(n: number): number {
   return count;
 }
 
-// BCS parsing function for inbox items
+/**
+ * BCS parsing function for inbox items
+ */
 export function parseInboxItemNative(base64VecU8: string) {
   const outer = fromBase64(base64VecU8); // bytes of vector<u8>
   const inner = bcs.vector(bcs.u8()).parse(outer); // extract inner bytes[]
@@ -271,7 +273,95 @@ export function parseInboxItemNative(base64VecU8: string) {
 export function extractNttCommonPackageId(inboxType: string): string {
   const match = inboxType.match("<(.+)>")?.[1]?.split("::")[0];
   if (!match) {
-    throw new Error(`Unable to extract NTT common package ID from inbox type: ${inboxType}`);
+    throw new Error(
+      `Unable to extract NTT common package ID from inbox type: ${inboxType}`
+    );
   }
   return match;
+}
+
+/**
+ * Creates Move objects for NttManagerMessage construction in a Sui transaction
+ */
+export function createNttManagerMessageObjects(
+  txb: any,
+  nttCommonPackageId: string,
+  wormholeCoreBridgePackageId: string,
+  messageBytes: Uint8Array,
+  messageId: Uint8Array,
+  senderAddress: Uint8Array
+) {
+  // Create the native token transfer object from the serialized payload
+  const [native_token_transfer] = txb.moveCall({
+    target: `${nttCommonPackageId}::native_token_transfer::parse`,
+    arguments: [txb.pure.vector("u8", messageBytes)],
+  });
+
+  // Create the message ID from bytes
+  const [id] = txb.moveCall({
+    target: `${wormholeCoreBridgePackageId}::bytes32::from_bytes`,
+    arguments: [txb.pure.vector("u8", messageId)],
+  });
+
+  // Create the sender external address
+  const [sender] = txb.moveCall({
+    target: `${wormholeCoreBridgePackageId}::external_address::from_address`,
+    arguments: [
+      txb.pure.address("0x" + Buffer.from(senderAddress).toString("hex")),
+    ],
+  });
+
+  // Create the NttManagerMessage object
+  const [manager_message] = txb.moveCall({
+    target: `${nttCommonPackageId}::ntt_manager_message::new`,
+    typeArguments: [
+      `${nttCommonPackageId}::native_token_transfer::NativeTokenTransfer`,
+    ],
+    arguments: [id!, sender!, native_token_transfer!],
+  });
+
+  return manager_message;
+}
+
+/**
+ * Parses the result of devInspectTransactionBlock to extract and deserialize inbox item data
+ */
+export function parseInboxItemResult(
+  inspectResult: any,
+  threshold: number
+): { inboxItemFields: any; threshold: number } {
+  if (!inspectResult.results || inspectResult.results.length === 0) {
+    throw new Error("No results returned from devInspectTransactionBlock");
+  }
+
+  // Get the last result which contains the serialized inbox item bytes from bcs::to_bytes call
+  const lastResult = inspectResult.results[inspectResult.results.length - 1];
+  const serializedInboxItem = lastResult?.returnValues?.[0];
+
+  if (!Array.isArray(serializedInboxItem)) {
+    throw new Error("Invalid result format from devInspectTransactionBlock");
+  }
+
+  const [bytesData, type] = serializedInboxItem;
+  if (type !== "vector<u8>" || !Array.isArray(bytesData)) {
+    throw new Error(`Expected vector<u8> but got ${type}`);
+  }
+
+  // Parse the serialized InboxItem using BCS
+  // The data is wrapped as vector<u8>, so we need to unwrap it first
+  const outerBytes = new Uint8Array(bytesData);
+  const innerBytes = bcs.vector(bcs.u8()).parse(outerBytes);
+  const parsedInboxItem = InboxItemNative.parse(Uint8Array.from(innerBytes));
+
+  const inboxItemFields = {
+    votes: {
+      fields: {
+        bitmap: parsedInboxItem.votes.bitmap.toString(),
+      },
+    },
+    release_status: parsedInboxItem.release_status,
+    data: parsedInboxItem.data,
+  };
+
+  return { inboxItemFields, threshold };
 }


### PR DESCRIPTION
This will replace the previous logic to retrieve inbox item where we iterate through all dynamic fields in the manager contract. Instead we will call the onchain function borrow_inbox_item to get a reference to the inbox item and parse that to be used in tracking the transaction.