### PR TITLE
ts sdk: 2.5.0 version bump

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3991,7 +3991,7 @@ function searchBufferInBinary(binaryPath: string, searchBuffer: Buffer): boolean
 }
 
 function getSlowFlag(chain: Chain): string {
-    return chain === "Mezo" || chain === "HyperEVM" ? "--slow" : "";
+    return chain === "Mezo" || chain === "HyperEVM" || chain == "XRPLEVM" ? "--slow" : "";
 }
 
 export function ensureNttRoot(pwd: string = ".") {

--- a/evm/ts/package.json
+++ b/evm/ts/package.json
@@ -48,10 +48,10 @@
     "ethers": "^6.5.1"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^2.4.0",
-    "@wormhole-foundation/sdk-definitions": "^2.4.0",
-    "@wormhole-foundation/sdk-evm": "^2.4.0",
-    "@wormhole-foundation/sdk-evm-core": "^2.4.0"
+    "@wormhole-foundation/sdk-base": "^2.5.0",
+    "@wormhole-foundation/sdk-definitions": "^2.5.0",
+    "@wormhole-foundation/sdk-evm": "^2.5.0",
+    "@wormhole-foundation/sdk-evm-core": "^2.5.0"
   },
   "devDependencies": {
     "@typechain/ethers-v6": "^0.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@solana/web3.js": "^1.95.8",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.2",
-        "@wormhole-foundation/sdk": "^2.4.0",
+        "@wormhole-foundation/sdk": "^2.5.0",
         "@wormhole-foundation/wormchain-sdk": "^0.0.1",
         "ethers": "^6.5.1",
         "ts-jest": "^29.1.2",
@@ -107,10 +107,10 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^2.4.0",
-        "@wormhole-foundation/sdk-definitions": "^2.4.0",
-        "@wormhole-foundation/sdk-evm": "^2.4.0",
-        "@wormhole-foundation/sdk-evm-core": "^2.4.0"
+        "@wormhole-foundation/sdk-base": "^2.5.0",
+        "@wormhole-foundation/sdk-definitions": "^2.5.0",
+        "@wormhole-foundation/sdk-evm": "^2.5.0",
+        "@wormhole-foundation/sdk-evm-core": "^2.5.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -2461,9 +2461,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/abacus-proto-ts/node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2485,9 +2485,9 @@
       }
     },
     "node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.15.0.tgz",
-      "integrity": "sha512-J1Iq42RSfW8M5XDVDF8ACz49RkrP/963Lgyi1Yn9e4P2CZ2kRhJm8KSfH++1+yyLbDCEVdGj4b63TK8DopGsTA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.16.1.tgz",
+      "integrity": "sha512-/6LWwZ/ZcC6/sI21s92cf3/8mgma6xRnBXtsF+708g2SX87WatJuXL8DjZsY1agCCnyw6bLVLtjKAfLQopNkxw==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -2503,9 +2503,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/core-proto-ts/node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2527,9 +2527,9 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.15.39",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.15.39.tgz",
-      "integrity": "sha512-kNp/FBXEr4ObC8ET6aORuX9/rJ9mxu9EUWilOWIBVfyX69SgC6y0yHNGor4Jm1WmrGKRJnzuKXnRoEuCiYIO2A==",
+      "version": "1.16.10",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.16.10.tgz",
+      "integrity": "sha512-Tv0yM1JGSRzqtHp5fQlJ+B16Xej78WJrOqPrHC1H1MB9wr0NL3krAo86sm04IZI1RCq0Mv3hqCPPWqpZ6z+pRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-status-codes": "^2.3.0"
@@ -2584,9 +2584,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/indexer-proto-ts/node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2626,9 +2626,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/mito-proto-ts/node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2650,12 +2650,12 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.15.40.tgz",
-      "integrity": "sha512-584gCmBPirO2zXGSoIivprhlimqwvJKoKi8/Hj8yVaAQ1xXco4AQy8oD3GjJ12lx3gntl8/WpZtwL6k/YWymIg==",
+      "version": "1.16.10",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.10.tgz",
+      "integrity": "sha512-vdAKoMqJ7O3zEMaPzTcskDJfgS7zz6eSCQ7tJE7kIfStGEoK0aGJI7RdgWxfm4CApW4PKqb4u/LSmNkYHmMrww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/ts-types": "^1.15.40"
+        "@injectivelabs/ts-types": "1.16.10"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts": {
@@ -2677,9 +2677,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/olp-proto-ts/node_modules/protobufjs": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-      "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2701,9 +2701,9 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.15.42",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.15.42.tgz",
-      "integrity": "sha512-6qEM2aclj+u3gYsmgALFmTNUp8mltBpe96KrR0Xbn73zOECHni9hgOtLFZ4Hwbw+S+hznjj03M8YytVQ3ucsEA==",
+      "version": "1.16.10",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.16.10.tgz",
+      "integrity": "sha512-krRmlDzeKjJWZjIerVoIzN2ULgVVFvVlqbzOUfbv59KCJCU17e/6idadYlzBBxVa4r4Ybjs8A0fat7CjvVj0pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.13.1",
@@ -2711,17 +2711,17 @@
         "@cosmjs/proto-signing": "^0.33.0",
         "@cosmjs/stargate": "^0.33.0",
         "@injectivelabs/abacus-proto-ts": "1.14.0",
-        "@injectivelabs/core-proto-ts": "1.15.0",
-        "@injectivelabs/exceptions": "^1.15.39",
+        "@injectivelabs/core-proto-ts": "1.16.1",
+        "@injectivelabs/exceptions": "1.16.10",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
         "@injectivelabs/indexer-proto-ts": "1.13.14",
         "@injectivelabs/mito-proto-ts": "1.13.2",
-        "@injectivelabs/networks": "^1.15.40",
+        "@injectivelabs/networks": "1.16.10",
         "@injectivelabs/olp-proto-ts": "1.13.4",
-        "@injectivelabs/ts-types": "^1.15.40",
-        "@injectivelabs/utils": "^1.15.40",
+        "@injectivelabs/ts-types": "1.16.10",
+        "@injectivelabs/utils": "1.16.10",
         "@metamask/eth-sig-util": "^8.2.0",
         "@noble/curves": "^1.8.1",
         "@noble/hashes": "^1.7.1",
@@ -2736,15 +2736,16 @@
         "graphql": "^16.10.0",
         "http-status-codes": "^2.2.0",
         "keccak256": "^1.0.6",
+        "rxjs": "7.8.2",
         "secp256k1": "^4.0.3",
         "shx": "^0.3.4",
         "snakecase-keys": "^5.4.1"
       }
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/@apollo/client": {
-      "version": "3.13.8",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.8.tgz",
-      "integrity": "sha512-YM9lQpm0VfVco4DSyKooHS/fDTiKQcCHfxr7i3iL6a0kP/jNO5+4NFK6vtRDxaYisd5BrwOZHLJpPBnvRVpKPg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.14.0.tgz",
+      "integrity": "sha512-0YQKKRIxiMlIou+SekQqdCo0ZTHxOcES+K8vKB53cIDpwABNR0P0yRzPgsbgcj3zRJniD93S/ontsnZsCLZrxQ==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -2916,21 +2917,21 @@
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.15.40.tgz",
-      "integrity": "sha512-X57I9STRY+Njz0sBT3C/CniBzgXWbqW93lgpINIJlHI0PKuYucfBCRErMg74n4cDCV07AArsS9BdxfQe6AxX6g==",
+      "version": "1.16.10",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.16.10.tgz",
+      "integrity": "sha512-ZkECbMz5zD2+pp3tHQzFnezuK1r23IgJc8SQ/Rbu+jogwGkQmHurQTLut0MfYFLKWaqfJPQhqndBs2Fm17NBAA==",
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.15.40.tgz",
-      "integrity": "sha512-2yGn7+0yft1EJ0Y5aC4R7vbABTWjNQNREmm/C+hN8xUnXKjaLaeZY0ynx7oVI33Izd8Nl+VQioYTz483iith9w==",
+      "version": "1.16.10",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.16.10.tgz",
+      "integrity": "sha512-0eOcKlQ9Uly9e3zgEmWlCA3uA2mPtmBH6qC94JQB/H2+dy+/3/OsksEuRTc5HJ8WIGKus/EtDbHygae/wkKz4w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bangjelkoski/store2": "^2.14.3",
-        "@injectivelabs/exceptions": "^1.15.39",
-        "@injectivelabs/networks": "^1.15.40",
-        "@injectivelabs/ts-types": "^1.15.40",
+        "@injectivelabs/exceptions": "1.16.10",
+        "@injectivelabs/networks": "1.16.10",
+        "@injectivelabs/ts-types": "1.16.10",
         "axios": "^1.8.1",
         "bignumber.js": "^9.1.2",
         "http-status-codes": "^2.3.0"
@@ -3363,9 +3364,9 @@
       }
     },
     "node_modules/@metamask/utils": {
-      "version": "11.4.2",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.4.2.tgz",
-      "integrity": "sha512-TygCcGmUbhmpxjYMm+mx68kRiJ80jYV54/Aa8gUFBv4cTX7ulX2XZKr8CJoJAw3K3FN5ZvCRmU0IzWZFaonwhA==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.5.0.tgz",
+      "integrity": "sha512-fgPTBWyFhGp8VZ5HsWniY5qZIb9DfusRB8ssw8unGIomICCK+cnEcV2xajhpPJ6QPH62y1KyVHF+VbXKrgilLA==",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -3373,8 +3374,9 @@
         "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.3",
         "@types/debug": "^4.1.7",
+        "@types/lodash": "^4.17.20",
         "debug": "^4.3.4",
-        "lodash.memoize": "^4.1.2",
+        "lodash": "^4.17.21",
         "pony-cause": "^2.1.10",
         "semver": "^7.5.4",
         "uuid": "^9.0.1"
@@ -3998,6 +4000,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "license": "MIT"
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -4090,52 +4098,52 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-2.4.0.tgz",
-      "integrity": "sha512-3NwbCNyT/MdzoRtYXHDI0EBJJcTfJ5FHQX71nNcp87I/UcbOc/BHqRCOTKGL8CSSJR13fEAVCFmhZa2jcimQPg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-2.5.0.tgz",
+      "integrity": "sha512-muCdAh8D/GYhiN261/OMmUS137E7PUaOoJsQBVetxyzaaEoS1LOHm0RB/iKc3p+kalxXhAgJuyRrh4tRsddREg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "2.4.0",
-        "@wormhole-foundation/sdk-algorand-core": "2.4.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "2.4.0",
-        "@wormhole-foundation/sdk-aptos": "2.4.0",
-        "@wormhole-foundation/sdk-aptos-cctp": "2.4.0",
-        "@wormhole-foundation/sdk-aptos-core": "2.4.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "2.4.0",
-        "@wormhole-foundation/sdk-base": "2.4.0",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-cosmwasm": "2.4.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "2.4.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "2.4.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "2.4.0",
-        "@wormhole-foundation/sdk-definitions": "2.4.0",
-        "@wormhole-foundation/sdk-evm": "2.4.0",
-        "@wormhole-foundation/sdk-evm-cctp": "2.4.0",
-        "@wormhole-foundation/sdk-evm-core": "2.4.0",
-        "@wormhole-foundation/sdk-evm-portico": "2.4.0",
-        "@wormhole-foundation/sdk-evm-tbtc": "2.4.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "2.4.0",
-        "@wormhole-foundation/sdk-solana": "2.4.0",
-        "@wormhole-foundation/sdk-solana-cctp": "2.4.0",
-        "@wormhole-foundation/sdk-solana-core": "2.4.0",
-        "@wormhole-foundation/sdk-solana-tbtc": "2.4.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "2.4.0",
-        "@wormhole-foundation/sdk-sui": "2.4.0",
-        "@wormhole-foundation/sdk-sui-cctp": "2.4.0",
-        "@wormhole-foundation/sdk-sui-core": "2.4.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "2.4.0"
+        "@wormhole-foundation/sdk-algorand": "2.5.0",
+        "@wormhole-foundation/sdk-algorand-core": "2.5.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "2.5.0",
+        "@wormhole-foundation/sdk-aptos": "2.5.0",
+        "@wormhole-foundation/sdk-aptos-cctp": "2.5.0",
+        "@wormhole-foundation/sdk-aptos-core": "2.5.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "2.5.0",
+        "@wormhole-foundation/sdk-base": "2.5.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-cosmwasm": "2.5.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "2.5.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "2.5.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "2.5.0",
+        "@wormhole-foundation/sdk-definitions": "2.5.0",
+        "@wormhole-foundation/sdk-evm": "2.5.0",
+        "@wormhole-foundation/sdk-evm-cctp": "2.5.0",
+        "@wormhole-foundation/sdk-evm-core": "2.5.0",
+        "@wormhole-foundation/sdk-evm-portico": "2.5.0",
+        "@wormhole-foundation/sdk-evm-tbtc": "2.5.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "2.5.0",
+        "@wormhole-foundation/sdk-solana": "2.5.0",
+        "@wormhole-foundation/sdk-solana-cctp": "2.5.0",
+        "@wormhole-foundation/sdk-solana-core": "2.5.0",
+        "@wormhole-foundation/sdk-solana-tbtc": "2.5.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "2.5.0",
+        "@wormhole-foundation/sdk-sui": "2.5.0",
+        "@wormhole-foundation/sdk-sui-cctp": "2.5.0",
+        "@wormhole-foundation/sdk-sui-core": "2.5.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-2.4.0.tgz",
-      "integrity": "sha512-tO9ZgbTgVBHs4afm8G6WTAyZZubNL50VPu7m7bwBuE7yEi68j7AZ9sWrejH/+RhdINr275Pok539Mg9IB3GwcQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-2.5.0.tgz",
+      "integrity": "sha512-mE1jjKpf5V0SfgAjYPlYztcJ0lYQqhWnFztcbNcGgllQOvto/qrN/iQL9S7cPKfcbhhcd1UJaNMs5MPoOYiLig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "2.4.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -4143,102 +4151,103 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-2.4.0.tgz",
-      "integrity": "sha512-isqvcIQJwtUDwCfhpSvBgcebQfS2RXVew7jKnIz/4YXUkTjX7N4CzQ/yg0raUZRyB3y5iA/RRdvid94r2MHI8A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-2.5.0.tgz",
+      "integrity": "sha512-ZdJ4fdH4QARQVve+igruBR5cMtPF6m6ZzIoFKjLju3VVYkidAPjIUnjy4NxGFcTBrB1S7VK+slP0lcYIWx57Qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "2.4.0",
-        "@wormhole-foundation/sdk-connect": "2.4.0"
+        "@wormhole-foundation/sdk-algorand": "2.5.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-2.4.0.tgz",
-      "integrity": "sha512-aqx3H2LEoPnKQGjp5zJNg2wmVlPtUTsj07yVU96JJSBsBnNCADkcch87V1FOHwffAyUbUS1tw51NzTjjxoqeDg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-2.5.0.tgz",
+      "integrity": "sha512-lj2eDC7r4w+YxTzjBgO+HBCHlC9E2ZmpoxxbMw9Q9iaQ6Z8jMKljQtXmY0UrgoOh653NFXco7JnizSfIOev4uQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "2.4.0",
-        "@wormhole-foundation/sdk-algorand-core": "2.4.0",
-        "@wormhole-foundation/sdk-connect": "2.4.0"
+        "@wormhole-foundation/sdk-algorand": "2.5.0",
+        "@wormhole-foundation/sdk-algorand-core": "2.5.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-2.4.0.tgz",
-      "integrity": "sha512-F7Y+eZ5d6xXYamXJE4yVNtLjGBHfKwYzvAeFVKCTLI3QconoyMBSrC7sQhVA1PRLmjb3Phz36LaS7Y50ekThyA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-2.5.0.tgz",
+      "integrity": "sha512-SVOdh/EGol/wXqSbMqvTptZVicpcNWdRGjkMi3g8FEKQHApt32iPR7mKR6yQ2RwWdTi/GyRIqfV5Qu7L+91u0w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-2.4.0.tgz",
-      "integrity": "sha512-ZHcKRdqlV0ijD5g41ohwhjXG1N+YYgbMER2ZkS3P1EO5YmcjRKM8OtI4JqySOIKpF5+SGalZRDAouclWqdM3Cg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-2.5.0.tgz",
+      "integrity": "sha512-5pUXZRvq7U0KS1ntV/ntaTR1L8vy7LDQpfrpLPHPKtDp2HzH1MlxjcAVhf8gJXiJNOxAq0HHVvfNkcEqC2I6cQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "2.4.0",
-        "@wormhole-foundation/sdk-connect": "2.4.0"
+        "@wormhole-foundation/sdk-aptos": "2.5.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-2.4.0.tgz",
-      "integrity": "sha512-ZRICJ6fb2nis28Pf88mtRXqPoKtdErysGfn7tKebcfdWQJunoRxR2Kj73GN7kLH41+Xw7GUR3hZKl/Y+61i52g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-2.5.0.tgz",
+      "integrity": "sha512-8s9yB6aqofoTywiRwkrktIqP1H27SyKzTv8W11gBtkjUsHqle8w/zE7XnQOZJ1o9eYRPAD8OlqyE/1iZxGAScA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "2.4.0",
-        "@wormhole-foundation/sdk-connect": "2.4.0"
+        "@wormhole-foundation/sdk-aptos": "2.5.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-2.4.0.tgz",
-      "integrity": "sha512-dnsPzM9THVzryicxhty9g56eIshjLDnRn6MBy2T8rxHco8/saW2unCuL9qpVLJZhU4qBytTyGK6SgFGwxmWL5Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-2.5.0.tgz",
+      "integrity": "sha512-Kgp2TQO0rwT9Sq1ViL8ptIXcqJmqp8qPt4ksmdQGWdJ081n2RQK9asvx+iLuJQ61HCOGM7//uJmYzvxnOUUQkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "2.4.0",
-        "@wormhole-foundation/sdk-connect": "2.4.0"
+        "@wormhole-foundation/sdk-aptos": "2.5.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-2.4.0.tgz",
-      "integrity": "sha512-8LbhBMeiDgykZSYc3hkV48bUbasYppCTt3CBQltqBGNUO56sr08HLLCde7R1y9/15qmgQv4cijjp0i/0fNu5hA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-2.5.0.tgz",
+      "integrity": "sha512-oDpNAimvs3oy8uWeo/1MqDoyz+5S/VlYsgRCUHUIvWAolmU1wMzcHWSoiya+/sLwwpxPJEHHpXZ7q9OvTqs4EQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
         "binary-layout": "^1.0.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-2.4.0.tgz",
-      "integrity": "sha512-KyY9AC6o6I65M/B+J0s6v1NGGigU2Ghk7RJOSY7vErQ0cNcGjXVEdwrmbeEqKGkhMahawNLZcUiOVmAcPSoiYg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-2.5.0.tgz",
+      "integrity": "sha512-JeGnLTUdh8z+wm549oyBGHmMWAu9Zv8nBDAVEV5VKrFbgLXWLiBpZJhWNVcbOYoNyBXKaJyW5vQMxG4fPTG5NA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "2.4.0",
-        "@wormhole-foundation/sdk-definitions": "2.4.0",
+        "@wormhole-foundation/sdk-base": "2.5.0",
+        "@wormhole-foundation/sdk-definitions": "2.5.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -4246,16 +4255,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-2.4.0.tgz",
-      "integrity": "sha512-y67TtEfWzfiqInzdEF4GfxvRuN4Gefw7UPwzXGS4r0R34ALu3fUfkWhbCEy69MSFEPCGYNWvKJGZbAlLLCnyNQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-2.5.0.tgz",
+      "integrity": "sha512-82dNKZIqkXIfXD9LR3wH/tTxVY0zzhIxzElx61lUXkHugJVyvF6EU0JrDRlAX7AC0aUcitaR2L93mUolZn9pnQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -4263,33 +4272,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-2.4.0.tgz",
-      "integrity": "sha512-m+ZhcnOqbtJXaKJARbUhrKOB2vMWGDJkmzS5kNvjGItCumt9CLfLWwJKaR7gMqzh3EddPZadARx3zlqMISboTQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-2.5.0.tgz",
+      "integrity": "sha512-OWzEMb9ofQo8W3dBxlNSMzLRALqlFQgO7F2D8duXccAQUlGO8xQwB43gQAm3dQSEcXkbtZrBZw7YBC6BIJgqZQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-cosmwasm": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-cosmwasm": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-2.4.0.tgz",
-      "integrity": "sha512-1JGQNwmrnyTm60RNkKeC7Cb/ayPm//rZt27JBL6JgqEqUM1NxVVyz6b99KHTvNNV2TvMLVSx+NWTeWHlSyvLkQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-2.5.0.tgz",
+      "integrity": "sha512-+ZYDtmjzLKtrkrun5hNk1Srzd9ubjtdLLfVGy0+U73YDtNQW63CuwSXfeBZuLhsx+PW7GoANOE7XKLL6N7g80A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-cosmwasm": "2.4.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "2.4.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-cosmwasm": "2.5.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "2.5.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -4297,28 +4306,28 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-2.4.0.tgz",
-      "integrity": "sha512-YD8IT8xwp+0BDuRSwx4OHlCkdZwS9egcohDpiRZsr3MWzBehmb4wLBaQUvAlWLdTkpf6xak4zRPHsSDCiwicfg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-2.5.0.tgz",
+      "integrity": "sha512-dJTTitJY5vFwKQJHRF6dTBnLVkmT3su8CdwT56qW6f/wIHqAXc8kh+CHkKC3tsE4B0FIWg7S5xx1gR9Pbq2pDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-cosmwasm": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-cosmwasm": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-2.4.0.tgz",
-      "integrity": "sha512-Aqx3/XLaBzbt5kt70N0lnVj3acGe/DYN66R4lG7AVv7VvDTSj2PKC0qOdbKgMh+bzFbjKK03fJkpUzl/d6eo+A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-2.5.0.tgz",
+      "integrity": "sha512-brkjiawUGYMSyzCRBrMwwnIztrNZjCZD+vYb2YJaD1+2mDouNCMHdd1g/El4d/eAYdtFHb1kW0y3f2fmGEEZMQ==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "2.4.0"
+        "@wormhole-foundation/sdk-base": "2.5.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
@@ -4326,11 +4335,12 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-2.4.0.tgz",
-      "integrity": "sha512-RqlsY1782GRG1IYe1LCzMxCKTyQUghOCSKUzc9Oe/5n1U5wn8tYnxh7d6MmGWWRUy2xT6gY1ZrCfdmSrG1VyPQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-2.5.0.tgz",
+      "integrity": "sha512-G1bmHcTAtBHyc/l7KqDMsrh0ROq5g5SCzwlKBL3LH1iY3HAnodp2j4Wqy2FwX15mMNDxZjWvvBHNgXjwfDpfFA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "2.4.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4338,14 +4348,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-2.4.0.tgz",
-      "integrity": "sha512-kdVi8oDjGpl12C4LMYZ/yqr3+ege8QDtwxQQJ/a8nJ3dBhwmMWqr0sMcgxLu56kHLwUyB3zhhBKQbxjO3R6bdA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-2.5.0.tgz",
+      "integrity": "sha512-nexegJS/QVDdHo/xjycBx7oDkOC4Uu4c0gB0McZxawofp2nwNh1+NG3FYjzyPBfexn+11PQVS1CoqJYQMKzz2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-evm": "2.4.0",
-        "@wormhole-foundation/sdk-evm-core": "2.4.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-evm": "2.5.0",
+        "@wormhole-foundation/sdk-evm-core": "2.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4353,12 +4363,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-2.4.0.tgz",
-      "integrity": "sha512-FKT+BeslNi1Pevx6lCfL4IgxCxgaTMVonKUqZj+FSMHmXIiOQxPKslTVwmhK85jLoT9tfVYSUR9nxP7+YyFI7g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-2.5.0.tgz",
+      "integrity": "sha512-41RcEaN62hU9aPufhgISoAcyUcBEoZPzsEkCYvdgMFHz3A1KVD2zh2B0sqFFynh6vmCUcIdkN3n3RO9+23jeKA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-evm": "2.4.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-evm": "2.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4370,15 +4381,15 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-2.4.0.tgz",
-      "integrity": "sha512-NXBGAzDEUptnagb+PQTNN+fM7tHXaPlbRXguGczMXzGLv/sy/eRYuHJRRyHaJlnWUm0+wT8KZmb4h+pKLqYTrA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-2.5.0.tgz",
+      "integrity": "sha512-4S7ur6+jsG7l8TTa99fFnuGFvGZyUgccKVZnL4l059sKjpeiFJodI2s38Xo8LphWDNiPeK7kBBOlVrGjjN4NRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-evm": "2.4.0",
-        "@wormhole-foundation/sdk-evm-core": "2.4.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "2.4.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-evm": "2.5.0",
+        "@wormhole-foundation/sdk-evm-core": "2.5.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "2.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4386,14 +4397,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-2.4.0.tgz",
-      "integrity": "sha512-+aAIA38cKU75mJSB1NzePSLVCPXSG7jPqszUdEm9AWIB/gdv3HuH/UOuST/WlefU5dTjDsQHc5b5tEl+c7fKIA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-2.5.0.tgz",
+      "integrity": "sha512-okeMk1Ah5tbAbGsFqojhojc9YJypcJex5oKSAurl36KDLg6YhXKB5B8Qj1Dv/NxANiL3fBOfrkGPk53sbH/Ngg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-evm": "2.4.0",
-        "@wormhole-foundation/sdk-evm-core": "2.4.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-evm": "2.5.0",
+        "@wormhole-foundation/sdk-evm-core": "2.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4401,14 +4412,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-2.4.0.tgz",
-      "integrity": "sha512-msyS03Q18Ue58MgCzukcJMLbMtcM0sgA4BEe3uoNH7rADIybUaCwZ31H6R0At3870dJ5RJvDwT0HBhXmeIR1vg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-2.5.0.tgz",
+      "integrity": "sha512-8R/7w5ZYvF4IeXUcNRtWQRiVDUg0cIhvdzWPsL4tXehs2QF+2j5fK5M9+XB3tOOJAwdxmoFM0GhbONYHWXdABw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-evm": "2.4.0",
-        "@wormhole-foundation/sdk-evm-core": "2.4.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-evm": "2.5.0",
+        "@wormhole-foundation/sdk-evm-core": "2.5.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -4424,15 +4435,16 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-2.4.0.tgz",
-      "integrity": "sha512-OCH0INsRZoLb40nqQFST3l3jgOSmFsEBr6D8gqfwEa/TAgL53x9W6LO7gs9UHnV46+UU3jgDeyz84YjqUGzX/A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-2.5.0.tgz",
+      "integrity": "sha512-TTuyzbRBvYXrQ7A21mP7cCismAbBHg24lDqisO2wNJ6wF2mtnO7/K/HHF2VcXu70aN4SvaKCF+FVJveDuyUiEw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
+        "@wormhole-foundation/sdk-connect": "2.5.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -4440,31 +4452,32 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-2.4.0.tgz",
-      "integrity": "sha512-GeL/pW9nQicODm+Lf3CZsAzssYbwVD1qGC+xtxCuftFcPQZMY9DyNUCar3XPe+mkM0EOMePbbamWo+hQWASOHg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-2.5.0.tgz",
+      "integrity": "sha512-HXEgVfGzA4NEu0tRJHshqYdS7Bt1z1nVTqlSz58CunNPBdnqX90H69zRCKLWVC7EEfBnWi+Bfo74TLFua/JtbA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-solana": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-solana": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-2.4.0.tgz",
-      "integrity": "sha512-ZLXHjnVf3QmGWw022ZhFLpj0m/Dg1GuBZTV0S9iKchrFlXm3LD5i7ekhEzaHmLCFUxOWe/berCXIcPeMBJfeBA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-2.5.0.tgz",
+      "integrity": "sha512-d8NprA3v81jSgWFOOpomDRbEZ5YpIyrryOCrTV9t7Ya+J7ifShLIk7eLSCbnQ1XkXbX/5rucOZ9E8RIc1z/bEQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-solana": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-solana": "2.5.0"
       },
       "engines": {
         "node": ">=16"
@@ -4475,74 +4488,76 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-2.4.0.tgz",
-      "integrity": "sha512-/ngGNO/auKy7yajeRxcXYq0j/+WruK60+ODAemwuAmMEHOVxWupc6zWtwSwlPoteN1Us6l1avKsemkWefQN0iw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-2.5.0.tgz",
+      "integrity": "sha512-/+4Qp8PHe39E8eITge0N8NA1vX4bBIb9V8hjfFzDdUbon/LRnA1iHWs7MwBVzOw04qcZ1ioXc2si2INgItleMQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-solana": "2.4.0",
-        "@wormhole-foundation/sdk-solana-core": "2.4.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-solana": "2.5.0",
+        "@wormhole-foundation/sdk-solana-core": "2.5.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-2.4.0.tgz",
-      "integrity": "sha512-zKXHRyUe/mAuULPag+gK9vp9+qOaL6AhD1TFoViusJ508HT5XzH/W6m0zMAAtLiS6QH5KvaUQs4Mxhslpq++mA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-2.5.0.tgz",
+      "integrity": "sha512-nQqmb3hpuYrD1W84Mhqtyk/Au6U7YwIFCqHsIZIHEy6qSR+mATGstUwevn8gzdT4SwVbPGrYlySJVDI/Kr+agw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-solana": "2.4.0",
-        "@wormhole-foundation/sdk-solana-core": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-solana": "2.5.0",
+        "@wormhole-foundation/sdk-solana-core": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-2.4.0.tgz",
-      "integrity": "sha512-kWOvd/q57dar9M5Lh5XZwpJ33NencnYLAKuefIqwPwstF/3nhSyOawOZNKF5to9r2io/OvlV/MZ7L6cPmlVQNQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-2.5.0.tgz",
+      "integrity": "sha512-JDCNI05AlslyRkr4knMcR42SBlSUN8jUc5ZNN2Fy8Hf1enfzLhitCGlBpQx4MK9nLfLg835Z7/qibN0QhRsqNA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-2.4.0.tgz",
-      "integrity": "sha512-l92V/9QaFg2BsE4Y1yfRpH1gSxbnX5hBUghFlgZpfV51rI2mxdCSFKfDCQsPcmHkjBS49Q61kpOSjYml3G8UDw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-2.5.0.tgz",
+      "integrity": "sha512-Fyb0RXXX3ZIhkcmPYWCsBZGvuepVDddBSv65NQ70gDE5DJITnbmT3kP/1JwxpyKbLyvrh7FtBIH6ALdfKsmJOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-sui": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-sui": "2.5.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-2.4.0.tgz",
-      "integrity": "sha512-y+E0lLRqFscXht6olP0xwtWvPx9Lv6D+9+k/PVeiHPyREusTQdDOFB6rymAvEFkLLASwiPHzdt4AnqyuLSXl3w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-2.5.0.tgz",
+      "integrity": "sha512-4Po/epxsOhzph6Qa8J62k62sQXiICBTOvlNu6zMTvoURDHSiJAebheJZBtXVG9oNU10O8yXrhef7GpQhbxwh9g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-sui": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-sui": "2.5.0"
       },
       "engines": {
         "node": ">=16"
@@ -4553,15 +4568,15 @@
       "link": true
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-2.4.0.tgz",
-      "integrity": "sha512-fDfmn0OmDyXH64NFyN8T9GQVtqBngvAXctoBg6Ob8559FByFveXVaqSRLvVOc+EZkWxhkCAiFj2FYiHDN37WOA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-2.5.0.tgz",
+      "integrity": "sha512-zfWYO3gMgrc5mHJR8o9MO6uZn5GfdAeKLH4LAXTsknh3YZT6czCi6ODwKHTYx/Rpfv7OL+MhsZpchmcRZ8TmUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "2.4.0",
-        "@wormhole-foundation/sdk-sui": "2.4.0",
-        "@wormhole-foundation/sdk-sui-core": "2.4.0"
+        "@wormhole-foundation/sdk-connect": "2.5.0",
+        "@wormhole-foundation/sdk-sui": "2.5.0",
+        "@wormhole-foundation/sdk-sui-core": "2.5.0"
       },
       "engines": {
         "node": ">=16"
@@ -10865,8 +10880,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -10877,7 +10891,8 @@
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
     },
     "node_modules/long": {
       "version": "4.0.0",
@@ -11980,9 +11995,10 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -13457,8 +13473,8 @@
       "name": "@wormhole-foundation/sdk-definitions-ntt",
       "version": "1.0.0",
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^2.4.0",
-        "@wormhole-foundation/sdk-definitions": "^2.4.0"
+        "@wormhole-foundation/sdk-base": "^2.5.0",
+        "@wormhole-foundation/sdk-definitions": "^2.5.0"
       }
     },
     "sdk/evm": {
@@ -13487,7 +13503,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk": "^2.4.0",
+        "@wormhole-foundation/sdk": "^2.5.0",
         "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
         "@wormhole-foundation/sdk-evm-ntt": "1.0.0",
         "@wormhole-foundation/sdk-route-ntt": "1.0.0",
@@ -13533,7 +13549,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-connect": "^2.4.0",
+        "@wormhole-foundation/sdk-connect": "^2.5.0",
         "axios": "^1.9.0"
       }
     },
@@ -13560,10 +13576,10 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^2.4.0",
-        "@wormhole-foundation/sdk-definitions": "^2.4.0",
-        "@wormhole-foundation/sdk-solana": "^2.4.0",
-        "@wormhole-foundation/sdk-solana-core": "^2.4.0"
+        "@wormhole-foundation/sdk-base": "^2.5.0",
+        "@wormhole-foundation/sdk-definitions": "^2.5.0",
+        "@wormhole-foundation/sdk-solana": "^2.5.0",
+        "@wormhole-foundation/sdk-solana-core": "^2.5.0"
       }
     },
     "solana/node_modules/@solana/codecs-core": {
@@ -13665,10 +13681,10 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@wormhole-foundation/sdk-base": "^2.4.0",
-        "@wormhole-foundation/sdk-definitions": "^2.4.0",
-        "@wormhole-foundation/sdk-sui": "^2.4.0",
-        "@wormhole-foundation/sdk-sui-core": "^2.4.0"
+        "@wormhole-foundation/sdk-base": "^2.5.0",
+        "@wormhole-foundation/sdk-definitions": "^2.5.0",
+        "@wormhole-foundation/sdk-sui": "^2.5.0",
+        "@wormhole-foundation/sdk-sui-core": "^2.5.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@solana/web3.js": "^1.95.8",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.2",
-    "@wormhole-foundation/sdk": "^2.4.0",
+    "@wormhole-foundation/sdk": "^2.5.0",
     "@wormhole-foundation/wormchain-sdk": "^0.0.1",
     "ethers": "^6.5.1",
     "ts-jest": "^29.1.2",

--- a/sdk/definitions/package.json
+++ b/sdk/definitions/package.json
@@ -49,8 +49,8 @@
     "test": "jest --config ./jest.config.ts"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^2.4.0",
-    "@wormhole-foundation/sdk-definitions": "^2.4.0"
+    "@wormhole-foundation/sdk-base": "^2.5.0",
+    "@wormhole-foundation/sdk-definitions": "^2.5.0"
   },
   "type": "module"
 }

--- a/sdk/examples/package.json
+++ b/sdk/examples/package.json
@@ -32,10 +32,10 @@
     "tsx": "^4.7.2"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "^2.4.0",
+    "@wormhole-foundation/sdk": "^2.5.0",
     "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
     "@wormhole-foundation/sdk-evm-ntt": "1.0.0",
-    "@wormhole-foundation/sdk-solana-ntt": "1.0.0",
-    "@wormhole-foundation/sdk-route-ntt": "1.0.0"
+    "@wormhole-foundation/sdk-route-ntt": "1.0.0",
+    "@wormhole-foundation/sdk-solana-ntt": "1.0.0"
   }
 }

--- a/sdk/route/package.json
+++ b/sdk/route/package.json
@@ -50,7 +50,7 @@
     "@wormhole-foundation/sdk-solana-ntt": "1.0.0"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-connect": "^2.4.0",
+    "@wormhole-foundation/sdk-connect": "^2.5.0",
     "axios": "^1.9.0"
   },
   "type": "module",

--- a/solana/package.json
+++ b/solana/package.json
@@ -53,14 +53,14 @@
     "@coral-xyz/borsh": "0.29.0",
     "@solana/spl-token": "0.4.0",
     "@solana/web3.js": "^1.95.8",
-    "bn.js": "5.2.1",
-    "@wormhole-foundation/sdk-definitions-ntt": "1.0.0"
+    "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
+    "bn.js": "5.2.1"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^2.4.0",
-    "@wormhole-foundation/sdk-definitions": "^2.4.0",
-    "@wormhole-foundation/sdk-solana": "^2.4.0",
-    "@wormhole-foundation/sdk-solana-core": "^2.4.0"
+    "@wormhole-foundation/sdk-base": "^2.5.0",
+    "@wormhole-foundation/sdk-definitions": "^2.5.0",
+    "@wormhole-foundation/sdk-solana": "^2.5.0",
+    "@wormhole-foundation/sdk-solana-core": "^2.5.0"
   },
   "type": "module",
   "exports": {

--- a/sui/ts/package.json
+++ b/sui/ts/package.json
@@ -40,14 +40,14 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk-definitions-ntt": "1.0.0",
-    "@mysten/sui": "1.37.2"
+    "@mysten/sui": "1.37.2",
+    "@wormhole-foundation/sdk-definitions-ntt": "1.0.0"
   },
   "peerDependencies": {
-    "@wormhole-foundation/sdk-base": "^2.4.0",
-    "@wormhole-foundation/sdk-definitions": "^2.4.0",
-    "@wormhole-foundation/sdk-sui": "^2.4.0",
-    "@wormhole-foundation/sdk-sui-core": "^2.4.0"
+    "@wormhole-foundation/sdk-base": "^2.5.0",
+    "@wormhole-foundation/sdk-definitions": "^2.5.0",
+    "@wormhole-foundation/sdk-sui": "^2.5.0",
+    "@wormhole-foundation/sdk-sui-core": "^2.5.0"
   },
   "type": "module",
   "exports": {


### PR DESCRIPTION
This PR adds support for XRPL EVM to the CLI 🙂 

steps I did

```bash
npm ci
npm install @wormhole-foundation/sdk@2.5.0
cd sdk/examples
npm install @wormhole-foundation/sdk@2.5.0
cd ../../evm/ts 
npm r @wormhole-foundation/sdk-base @wormhole-foundation/sdk-definitions
cd ../../solana
npm r @wormhole-foundation/sdk-base @wormhole-foundation/sdk-definitions
cd ../sui/ts
npm r @wormhole-foundation/sdk-base @wormhole-foundation/sdk-definitions
cd ../../sdk/definitions
npm i --save-peer @wormhole-foundation/sdk-base@2.5.0 @wormhole-foundation/sdk-definitions@2.5.0
cd ../../evm/ts
npm i --save-peer @wormhole-foundation/sdk-base@2.5.0 @wormhole-foundation/sdk-definitions@2.5.0 @wormhole-foundation/sdk-evm@2.5.0 @wormhole-foundation/sdk-evm-core@2.5.0
cd ../../solana
npm i --save-peer @wormhole-foundation/sdk-base@2.5.0 @wormhole-foundation/sdk-definitions@2.5.0 @wormhole-foundation/sdk-solana@2.5.0 @wormhole-foundation/sdk-solana-core@2.5.0
cd ../sui/ts
npm i --save-peer @wormhole-foundation/sdk-base@2.5.0 @wormhole-foundation/sdk-definitions@2.5.0 @wormhole-foundation/sdk-sui@2.5.0 @wormhole-foundation/sdk-sui-core@2.5.0
cd ../../sdk/route
npm i --save-peer @wormhole-foundation/sdk-connect@2.5.0
cd ../..
```

the removals were necessary to resolve the peer dependency conflicts and appropriately update the packages.