### PR TITLE
solana: Update `deregister_transceiver` to error when trying to remove last enabled transceiver

### DIFF
--- a/solana/programs/example-native-token-transfers/src/instructions/admin/mod.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/admin/mod.rs
@@ -166,11 +166,14 @@ pub fn deregister_transceiver(ctx: Context<DeregisterTransceiver>) -> Result<()>
         .enabled_transceivers
         .set(ctx.accounts.registered_transceiver.id, false)?;
 
-    // decrement threshold if too high
     let num_enabled_transceivers = ctx.accounts.config.enabled_transceivers.len();
+    // at least one transceiver should be enabled
+    if num_enabled_transceivers == 0 {
+        return Err(NTTError::ZeroThreshold.into());
+    }
+    // decrement threshold if too high
     if num_enabled_transceivers < ctx.accounts.config.threshold {
-        // threshold should be at least 1
-        ctx.accounts.config.threshold = num_enabled_transceivers.max(1);
+        ctx.accounts.config.threshold = num_enabled_transceivers;
     }
     Ok(())
 }

--- a/solana/programs/example-native-token-transfers/tests/admin.rs
+++ b/solana/programs/example-native-token-transfers/tests/admin.rs
@@ -118,23 +118,11 @@ async fn test_reregister_all_transceivers() {
         .submit_with_signers(&[&test_data.program_owner], &mut ctx)
         .await
         .unwrap();
+        // assert threshold decreases
         assert_threshold(&mut ctx, num_dummy_transceivers - idx as u8).await;
     }
 
-    // deregister baked-in transceiver
-    deregister_transceiver(
-        &good_ntt,
-        DeregisterTransceiver {
-            owner: test_data.program_owner.pubkey(),
-            transceiver: example_native_token_transfers::ID,
-        },
-    )
-    .submit_with_signers(&[&test_data.program_owner], &mut ctx)
-    .await
-    .unwrap();
-    assert_threshold(&mut ctx, 1).await;
-
-    // reregister dummy transceiver
+    // reregister dummy transceivers
     for (idx, transceiver) in dummy_transceivers.iter().enumerate() {
         register_transceiver(
             &good_ntt,
@@ -147,6 +135,7 @@ async fn test_reregister_all_transceivers() {
         .submit_with_signers(&[&test_data.program_owner], &mut ctx)
         .await
         .unwrap();
+        // assert transceiver_id and threshold are retained
         assert_transceiver_id(&mut ctx, transceiver, idx as u8 + 1).await;
         assert_threshold(&mut ctx, 1).await;
     }
@@ -163,6 +152,7 @@ async fn test_reregister_all_transceivers() {
     .submit_with_signers(&[&test_data.program_owner], &mut ctx)
     .await
     .unwrap();
+    // assert transceiver_id and threshold are retained
     assert_transceiver_id(&mut ctx, &example_native_token_transfers::ID, 0).await;
     assert_threshold(&mut ctx, 1).await;
 }

--- a/solana/programs/example-native-token-transfers/tests/admin.rs
+++ b/solana/programs/example-native-token-transfers/tests/admin.rs
@@ -158,7 +158,7 @@ async fn test_reregister_all_transceivers() {
 }
 
 #[tokio::test]
-async fn test_deregister_final_enabled_transceiver() {
+async fn test_deregister_last_enabled_transceiver() {
     let (mut ctx, test_data) = setup(Mode::Locking).await;
 
     // attempt to deregister only enabled transceiver (baked-in transceiver)
@@ -206,7 +206,7 @@ async fn test_deregister_final_enabled_transceiver() {
     .await
     .unwrap();
 
-    // attempt to deregister final enabled transceiver (dummy transceiver)
+    // attempt to deregister last enabled transceiver (dummy transceiver)
     let err = deregister_transceiver(
         &good_ntt,
         DeregisterTransceiver {


### PR DESCRIPTION
Resolves: https://github.com/wormhole-foundation/native-token-transfers/issues/692

This returns `ZeroThreshold` error to mimic EVM that implicitly does the same.
This PR also adds a unit test to check for this invariant.